### PR TITLE
feat(x13): add laptop management scripts

### DIFF
--- a/laptop/x13-flow/agents.md
+++ b/laptop/x13-flow/agents.md
@@ -1,0 +1,57 @@
+# Agent Notes for `laptop/x13-flow`
+
+This folder contains RCA notes and utility scripts for running the ASUS ROG X13 Flow (`rog-x13-flow`) as a mostly headless/tent-mode server.
+
+## Current state
+
+- Current mitigation kernel: `6.8.0-90-generic`
+- Problem kernel: `6.8.0-110-generic`
+- GRUB default was changed with `./set-grub-kernel-6.8.0-90.sh`.
+- Kernel oops auto-reboot was enabled with `./setup-panic-on-oops.sh`:
+  - `kernel.panic_on_oops = 1`
+  - `kernel.panic = 30`
+- NVIDIA dGPU should remain disabled for server use.
+- `supergfxctl` graphics mode should be `Integrated`.
+- LightDM/display manager may be disabled; machine may run in `multi-user.target`.
+
+## Important files
+
+- `laptop-hang-rca.md` — primary RCA/timeline; update this after meaningful findings.
+- `screen.sh` — headless/tent-mode panel control:
+  - `./screen.sh --off`
+  - `./screen.sh --on`
+  - `./screen.sh --status`
+- `setup-hang-monitoring.sh` — installs `/var/log/hang-health.log` collection.
+- `setup-panic-on-oops.sh` — configures auto-reboot after kernel oops/panic.
+- `set-grub-kernel-6.8.0-90.sh` — sets GRUB default to older stable-test kernel.
+
+## Investigation pattern after a hang/reboot
+
+Run:
+
+```bash
+last -x | head -30
+journalctl --list-boots --no-pager | tail
+journalctl -b -1 -p warning..alert --no-pager | tail -300
+journalctl -b -1 -k --no-pager | tail -300
+tail -500 /var/log/hang-health.log
+uname -r
+prime-select query 2>/dev/null || true
+supergfxctl -g 2>/dev/null || true
+lsmod | grep '^nvidia' || true
+nvidia-smi || true
+```
+
+Interpretation notes:
+
+- `kmem_cache_alloc`, `anon_vma_*`, `copy_process`, `kernel_clone`, fork/exec faults point to kernel VM/slab corruption or RAM/hardware instability.
+- Normal health snapshots before failure plus no OOM/thermal spike makes thermal/OOM unlikely.
+- SSH can fail even while console logging works if fork/exec/memory allocation paths are corrupted.
+- If `6.8.0-90-generic` stays stable, suspect `6.8.0-110-generic` regression.
+- If the issue recurs across kernels, recommend overnight memtest/hardware diagnostics.
+
+## Be careful
+
+- Do not assume display sleep is the root cause; the 2026-06-23 incident was a kernel oops/VM corruption pattern.
+- Do not re-enable NVIDIA/dGPU unless explicitly needed.
+- Prefer updating `laptop-hang-rca.md` with dates/timeline when new evidence is found.

--- a/laptop/x13-flow/disable-nvidia-dgpu.sh
+++ b/laptop/x13-flow/disable-nvidia-dgpu.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'Current PRIME mode: '
+prime-select query || true
+
+printf '\nSwitching to integrated-GPU mode (prime-select intel)...\n'
+sudo prime-select intel
+
+printf '\nDisabling NVIDIA persistence daemon...\n'
+sudo systemctl disable --now nvidia-persistenced.service 2>/dev/null || true
+
+printf '\nCurrent NVIDIA module/process state before reboot:\n'
+lsmod | grep '^nvidia' || printf 'No NVIDIA kernel modules listed.\n'
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    nvidia-smi || true
+else
+    printf 'nvidia-smi not found.\n'
+fi
+
+printf '\nDone. Reboot when convenient for the PRIME mode change to fully take effect.\n'
+printf 'After reboot, verify with:\n'
+printf '  prime-select query\n'
+printf '  lsmod | grep nvidia\n'
+printf '  nvidia-smi\n'

--- a/laptop/x13-flow/enable-lightdm-display-sleep.sh
+++ b/laptop/x13-flow/enable-lightdm-display-sleep.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'Installing LightDM login-screen display sleep config...\n'
+
+sudo install -d -m 0755 /etc/lightdm/scripts /etc/lightdm/lightdm.conf.d
+
+sudo tee /etc/lightdm/scripts/display-sleep.sh >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set +e
+
+# Run by LightDM after the X server starts. Applies to the login/greeter screen.
+export DISPLAY="${DISPLAY:-:0}"
+export XAUTHORITY="${XAUTHORITY:-/var/run/lightdm/root/:0}"
+
+# Blank screen after 5 min, DPMS standby after 5 min, suspend after 10 min, off after 15 min.
+xset s blank
+xset s 300 300
+xset +dpms
+xset dpms 300 600 900
+EOF
+
+sudo chmod 0755 /etc/lightdm/scripts/display-sleep.sh
+
+sudo tee /etc/lightdm/lightdm.conf.d/99-display-sleep.conf >/dev/null <<'EOF'
+[Seat:*]
+# Apply once when the X server starts, then again after the greeter starts.
+# Some greeters reset screensaver/DPMS settings, so both hooks are intentional.
+display-setup-script=/etc/lightdm/scripts/display-sleep.sh
+greeter-setup-script=/etc/lightdm/scripts/display-sleep.sh
+EOF
+
+printf 'Done. Takes effect after restarting LightDM or rebooting.\n'
+printf 'To apply immediately, run from SSH/TTY only:\n'
+printf '  sudo systemctl restart lightdm\n'

--- a/laptop/x13-flow/fix-blacklist-nouveau.sh
+++ b/laptop/x13-flow/fix-blacklist-nouveau.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'Writing clean /etc/modprobe.d/blacklist-nouveau.conf...\n'
+sudo tee /etc/modprobe.d/blacklist-nouveau.conf >/dev/null <<'EOF'
+blacklist nouveau
+options nouveau modeset=0
+EOF
+
+printf 'Rebuilding initramfs...\n'
+sudo update-initramfs -u
+
+printf 'Done.\n'

--- a/laptop/x13-flow/install-asus-linux-tools.sh
+++ b/laptop/x13-flow/install-asus-linux-tools.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install ASUS Linux graphics tooling on Linux Mint 22.x.
+#
+# Installs from upstream source because the old ASUS Linux OBS apt repo does
+# not currently publish xUbuntu_24.04 packages.
+#
+# Default behavior is conservative/idempotent:
+#   - install missing build dependencies only
+#   - install supergfxctl only if missing
+#   - install asusctl only if missing and INSTALL_ASUSCTL=1
+#   - do not git pull/rebuild already-installed tools unless --update is passed
+#
+# Usage:
+#   ./install-asus-linux-tools.sh
+#   ./install-asus-linux-tools.sh --update
+#
+# Set INSTALL_ASUSCTL=0 to skip asusctl/asusd.
+
+SRC_ROOT="${SRC_ROOT:-$HOME/.local/src/asus-linux}"
+INSTALL_ASUSCTL="${INSTALL_ASUSCTL:-1}"
+UPDATE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --update) UPDATE=1 ;;
+    -h|--help)
+      sed -n '1,35p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      echo "Usage: $0 [--update]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+have_cmd() { command -v "$1" >/dev/null 2>&1; }
+have_pkg() { dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q 'install ok installed'; }
+
+install_missing_pkgs() {
+  local missing=()
+  for pkg in "$@"; do
+    if ! have_pkg "$pkg"; then
+      missing+=("$pkg")
+    fi
+  done
+
+  if [ "${#missing[@]}" -eq 0 ]; then
+    printf 'All required apt packages already installed.\n'
+    return 0
+  fi
+
+  printf 'Installing missing apt packages: %s\n' "${missing[*]}"
+  sudo apt update
+  sudo apt install -y "${missing[@]}"
+}
+
+clone_or_update() {
+  local repo_url="$1"
+  local dest="$2"
+
+  if [ -d "$dest/.git" ]; then
+    if [ "$UPDATE" = "1" ]; then
+      git -C "$dest" pull --ff-only
+    else
+      printf 'Source checkout exists, not updating without --update: %s\n' "$dest"
+    fi
+  else
+    git clone "$repo_url" "$dest"
+  fi
+}
+
+printf 'Cleaning any failed ASUS Linux OBS apt repo entries...\n'
+sudo rm -f /etc/apt/sources.list.d/asus-linux.list /etc/apt/trusted.gpg.d/asus-linux.gpg
+
+printf 'Checking build prerequisites...\n'
+install_missing_pkgs git curl build-essential pkg-config make libudev-dev
+
+if ! have_cmd cargo || ! have_cmd rustc; then
+  printf '\nRust/cargo not found. Install Rust first, then rerun this script:\n'
+  printf '  curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh\n'
+  printf '  source ~/.cargo/env\n'
+  exit 1
+fi
+
+mkdir -p "$SRC_ROOT"
+
+if have_cmd supergfxctl && [ "$UPDATE" = "0" ]; then
+  printf '\nsupergfxctl already installed; skipping rebuild. Use --update to rebuild/update.\n'
+else
+  printf '\nInstalling/updating supergfxctl from source...\n'
+  clone_or_update https://gitlab.com/asus-linux/supergfxctl.git "$SRC_ROOT/supergfxctl"
+  make -C "$SRC_ROOT/supergfxctl"
+  sudo make -C "$SRC_ROOT/supergfxctl" install
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now supergfxd
+
+if [ "$INSTALL_ASUSCTL" = "1" ]; then
+  if have_cmd asusctl && systemctl list-unit-files asusd.service >/dev/null 2>&1 && [ "$UPDATE" = "0" ]; then
+    printf '\nasusctl/asusd already installed; skipping rebuild. Use --update to rebuild/update.\n'
+    sudo systemctl enable --now asusd || true
+  else
+    printf '\nInstalling/updating asusctl/asusd from source...\n'
+    install_missing_pkgs libclang-dev libudev-dev libfontconfig-dev cmake libxkbcommon-dev
+    clone_or_update https://gitlab.com/asus-linux/asusctl.git "$SRC_ROOT/asusctl"
+    make -C "$SRC_ROOT/asusctl"
+    sudo make -C "$SRC_ROOT/asusctl" install
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now asusd
+  fi
+else
+  printf '\nSkipping asusctl/asusd because INSTALL_ASUSCTL=0.\n'
+fi
+
+printf '\nInstalled status:\n'
+SYSTEMD_PAGER=cat systemctl --no-pager --full status supergfxd 2>/dev/null | sed -n '1,60p' || true
+if [ "$INSTALL_ASUSCTL" = "1" ]; then
+  SYSTEMD_PAGER=cat systemctl --no-pager --full status asusd 2>/dev/null | sed -n '1,60p' || true
+fi
+
+printf '\nGraphics mode:\n'
+# supergfxctl can occasionally block while the daemon is probing PCI state; don't let
+# the installer appear hung just because status probing is slow.
+timeout 10s supergfxctl -g || printf 'supergfxctl -g did not return within 10s; check later with: supergfxctl -g\n'
+
+printf '\nUseful commands:\n'
+printf '  supergfxctl -g                  # get current graphics mode\n'
+printf '  sudo supergfxctl -m Integrated  # switch to integrated-only mode\n'
+printf '  sudo supergfxctl -m Hybrid      # switch back to hybrid\n'
+printf '  supergfxctl --help\n'
+printf '  asusctl --help                  # if asusctl was installed\n'
+printf '\nBasic kernel platform profile fan/performance controls:\n'
+printf '  cat /sys/firmware/acpi/platform_profile_choices\n'
+printf '  cat /sys/firmware/acpi/platform_profile\n'
+printf '  echo quiet | sudo tee /sys/firmware/acpi/platform_profile\n'
+printf '  echo balanced | sudo tee /sys/firmware/acpi/platform_profile\n'
+printf '  echo performance | sudo tee /sys/firmware/acpi/platform_profile\n'
+printf '\nReboot after changing graphics mode.\n'

--- a/laptop/x13-flow/install-screen-keepoff-service.sh
+++ b/laptop/x13-flow/install-screen-keepoff-service.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCREEN_SH="$SCRIPT_DIR/screen.sh"
+SERVICE_NAME="x13-screen-off.service"
+TIMER_NAME="x13-screen-off.timer"
+
+if [[ ! -x "$SCREEN_SH" ]]; then
+  printf 'ERROR: %s is not executable or does not exist\n' "$SCREEN_SH" >&2
+  exit 1
+fi
+
+printf 'Installing %s and %s...\n' "$SERVICE_NAME" "$TIMER_NAME"
+
+sudo tee "/etc/systemd/system/$SERVICE_NAME" >/dev/null <<EOF
+[Unit]
+Description=Force ASUS X13 laptop panel off for headless/tent mode
+Documentation=file://$SCREEN_SH
+
+[Service]
+Type=oneshot
+ExecStart=$SCREEN_SH --apply-off
+EOF
+
+sudo tee "/etc/systemd/system/$TIMER_NAME" >/dev/null <<EOF
+[Unit]
+Description=Keep ASUS X13 laptop panel off for headless/tent mode
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=5s
+Unit=$SERVICE_NAME
+Persistent=false
+
+[Install]
+WantedBy=timers.target
+EOF
+
+sudo systemctl daemon-reload
+
+printf '\nInstalled. The timer is not enabled until you run:\n'
+printf '  %s --off\n' "$SCREEN_SH"
+printf '\nTo disable keep-off and restore screen:\n'
+printf '  %s --on\n' "$SCREEN_SH"
+printf '\nStatus:\n'
+printf '  %s --status\n' "$SCREEN_SH"

--- a/laptop/x13-flow/laptop-hang-rca.md
+++ b/laptop/x13-flow/laptop-hang-rca.md
@@ -2,13 +2,13 @@
 title: Laptop Hang RCA Notes
 host: rog-x13-flow
 initial_date: 2026-06-21
-last_updated: 2026-07-02
+last_updated: 2026-07-07
 os_stack: Linux Mint / Ubuntu
 problem_kernel: 6.8.0-110-generic
 current_mitigation_kernel: 6.8.0-90-generic
 current_status:
-  Running 6.8.0-90-generic after a sudden unclean reboot on 2026-07-02 with no preserved final
-  cause; reboot-investigation tooling prepared.
+  Running 6.8.0-90-generic after sudden unclean reboots on 2026-07-02 and 2026-07-07 with no
+  preserved final panic/oops cause; pstore did not capture the July 7 event.
 key_events:
   - date: 2026-06-21
     summary:
@@ -27,6 +27,11 @@ key_events:
     summary:
       Sudden unclean reboot on 6.8.0-90-generic; no oops/panic/OOM/thermal evidence preserved; added
       script to enable pstore archival, stronger panic-on-lockup sysctls, and timer dephasing.
+  - date: 2026-07-07
+    summary:
+      Second sudden unclean reboot on 6.8.0-90-generic; previous boot stopped abruptly at 17:43:48,
+      current boot began at 17:46:17; pstore empty; health snapshots showed no OOM, thermal, or disk
+      fault, but Docker/GitHub runner churn was high near the final logs.
 ---
 
 # Laptop Hang RCA Notes
@@ -203,6 +208,100 @@ sudo grep -R . /var/log/pstore-archive /sys/fs/pstore 2>/dev/null | less
 journalctl -b -1 -k --no-pager | tail -300
 last -x | head -30
 ```
+
+### 2026-07-07 second sudden unclean reboot on `6.8.0-90-generic`
+
+The laptop rebooted unexpectedly again while still on the rollback kernel:
+
+```text
+Current kernel after reboot: 6.8.0-90-generic
+Previous boot: Thu 2026-07-02 13:13:08 IST → Tue 2026-07-07 17:43:48 IST
+Current boot:  Tue 2026-07-07 17:46:17 IST
+Observed uptime after reconnect: ~1-2 minutes
+```
+
+The reboot was unclean. The current boot logged journal corruption/replacement:
+
+```text
+systemd-journald[444]: File /var/log/journal/.../system.journal corrupted or uncleanly shut down, renaming and replacing.
+```
+
+The previous boot journal ended abruptly at `17:43:48`; there was no clean shutdown/reboot sequence
+before the new boot at `17:46:17`. Searches did not find a preserved final cause:
+
+```text
+No kernel panic/oops in the final previous-boot journal.
+No OOM/out-of-memory evidence.
+No thermal critical event.
+No NVMe I/O errors, media errors, or SMART critical warnings.
+No pstore files under /sys/fs/pstore or /var/log/pstore-archive.
+```
+
+The last previous-boot log entries were dominated by Docker/container activity and GitHub Actions
+runner conflicts:
+
+```text
+Jul 07 17:43:46 dockerd: healthcheck failed fatally: ... only one connection allowed
+Jul 07 17:43:46 systemd: Started docker-...scope
+Jul 07 17:43:46 kernel: br-f359ba95c655: port ... entered forwarding state
+Jul 07 17:43:48 avahi-daemon: Registering new address record for ... on veth...
+Jul 07 17:43:48 systemd: var-lib-docker-overlay2-...-init-merged.mount: Deactivated successfully.
+```
+
+The health snapshots immediately before the reboot did not show classic resource exhaustion:
+
+```text
+snapshot: 2026-07-07T17:43:34+05:30
+uptime: 5 days, 4:31
+load average: 4.61, 1.74, 0.92
+memory: ~25 GiB available, swap ~512 KiB used
+root disk: 53% used
+AC online: 1
+battery: 57%, status=Charging, threshold=60, power_now≈7.3 W
+thermal_zone0: 68°C
+thermal_zone1: 20°C
+thermal_zone2/iwlwifi: 50°C
+```
+
+The next health snapshot was after reboot:
+
+```text
+snapshot: 2026-07-07T17:46:47+05:30
+uptime: 2 min
+memory: ~28 GiB available, swap 0B used
+battery: 59%, status=Discharging
+thermal_zone0: 68°C
+thermal_zone2/iwlwifi: 52°C
+```
+
+Daily NVMe health logging showed the disk itself was healthy near the event:
+
+```text
+SMART overall-health self-assessment: PASSED
+critical_warning: 0
+media_errors: 0
+num_err_log_entries: 0
+temperature: 33°C
+percentage_used: 2%
+```
+
+Interpretation: this matches the 2026-07-02 pattern more than the 2026-06-23
+`6.8.0-110-generic` oops pattern. It appears to be a sudden reset/firmware-level reboot/kernel
+hang where logs were not flushed, not an orderly shutdown and not an observed Linux OOM/thermal/NVMe
+failure. Docker/GitHub-runner churn was the most prominent workload near the final logs, but it is
+not proven as the root cause; it may only be the workload that made a latent kernel/firmware/power
+bug easier to trigger.
+
+Next investigation focus after this recurrence:
+
+1. Preserve pstore/kdump status immediately after every future reboot; July 7 had no pstore files.
+2. Fix known system noise so future evidence is cleaner:
+   - GitHub Actions runner duplicate-session/service failures.
+   - `x13-screen-off.timer.d/10-dephase.conf` parse warning.
+3. Consider testing PCIe/power-management mitigation such as `pcie_aspm=off` if sudden resets recur.
+4. Consider temporarily stopping Docker/GitHub runners to see whether idle/server uptime improves.
+5. If events continue on `6.8.0-90-generic`, escalate from "bad kernel 6.8.0-110" to broader ASUS
+   X13 Flow firmware/ACPI/PCIe/power-management or hardware instability investigation.
 
 ## Initial hypothesis checks
 

--- a/laptop/x13-flow/set-grub-kernel-6.8.0-90.sh
+++ b/laptop/x13-flow/set-grub-kernel-6.8.0-90.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL="${1:-6.8.0-90-generic}"
+GRUB_CFG="/boot/grub/grub.cfg"
+GRUB_DEFAULT_FILE="/etc/default/grub"
+
+printf 'Looking for non-recovery GRUB entry containing: %s\n' "$KERNEL"
+
+ENTRY="$(
+  sudo awk -v kernel="$KERNEL" '
+    /^[[:space:]]*submenu / {
+      if (match($0, /'"'"'[^'"'"']+'"'"'/)) {
+        submenu = substr($0, RSTART + 1, RLENGTH - 2)
+      }
+      next
+    }
+
+    /^[[:space:]]*menuentry / {
+      if (match($0, /'"'"'[^'"'"']+'"'"'/)) {
+        entry = substr($0, RSTART + 1, RLENGTH - 2)
+        if (index(entry, kernel) && entry !~ /recovery mode/) {
+          if (submenu != "") {
+            print submenu ">" entry
+          } else {
+            print entry
+          }
+          exit
+        }
+      }
+    }
+  ' "$GRUB_CFG"
+)"
+
+if [[ -z "$ENTRY" ]]; then
+  printf 'ERROR: Could not find a non-recovery GRUB entry for %s\n' "$KERNEL" >&2
+  printf 'Available matching entries:\n' >&2
+  sudo awk -v kernel="$KERNEL" '
+    /^[[:space:]]*menuentry / {
+      if (match($0, /'"'"'[^'"'"']+'"'"'/)) {
+        entry = substr($0, RSTART + 1, RLENGTH - 2)
+        if (index(entry, kernel)) print "  " entry
+      }
+    }
+  ' "$GRUB_CFG" >&2
+  exit 1
+fi
+
+printf 'Selected GRUB entry:\n  %s\n' "$ENTRY"
+printf 'Backing up %s...\n' "$GRUB_DEFAULT_FILE"
+sudo cp -a "$GRUB_DEFAULT_FILE" "$GRUB_DEFAULT_FILE.bak.$(date +%Y%m%d%H%M%S)"
+
+printf 'Setting GRUB_DEFAULT to selected entry...\n'
+if sudo grep -q '^GRUB_DEFAULT=' "$GRUB_DEFAULT_FILE"; then
+  sudo sed -i "s|^GRUB_DEFAULT=.*|GRUB_DEFAULT=\"$ENTRY\"|" "$GRUB_DEFAULT_FILE"
+else
+  printf 'GRUB_DEFAULT="%s"\n' "$ENTRY" | sudo tee -a "$GRUB_DEFAULT_FILE" >/dev/null
+fi
+
+printf 'Running update-grub...\n'
+sudo update-grub
+
+printf '\nDone. Reboot, then verify with:\n  uname -r\n\nExpected:\n  %s\n' "$KERNEL"

--- a/laptop/x13-flow/setup-hang-monitoring.sh
+++ b/laptop/x13-flow/setup-hang-monitoring.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'Installing system hang/health monitor...\n'
+
+sudo install -d -m 0755 /usr/local/sbin
+sudo tee /usr/local/sbin/hang-health-snapshot >/dev/null <<'EOF'
+#!/usr/bin/env bash
+set +e
+LOG=/var/log/hang-health.log
+{
+  echo '===== snapshot' "$(date --iso-8601=seconds)" '====='
+  echo '-- uptime/load --'
+  uptime
+  cat /proc/loadavg
+
+  echo '-- memory --'
+  free -h
+  awk '/MemAvailable|MemFree|SwapFree|Dirty|Writeback/ {print}' /proc/meminfo
+
+  echo '-- disk --'
+  df -h / /boot /home 2>/dev/null
+
+  echo '-- battery/ac --'
+  for ps in /sys/class/power_supply/*; do
+    [ -d "$ps" ] || continue
+    name=$(basename "$ps")
+    echo "[$name]"
+    for f in type status capacity charge_control_end_threshold online energy_now energy_full power_now voltage_now; do
+      [ -r "$ps/$f" ] && printf '  %s=%s\n' "$f" "$(cat "$ps/$f" 2>/dev/null)"
+    done
+  done
+
+  echo '-- thermal zones --'
+  for z in /sys/class/thermal/thermal_zone*; do
+    [ -r "$z/temp" ] || continue
+    type=$(cat "$z/type" 2>/dev/null)
+    temp=$(cat "$z/temp" 2>/dev/null)
+    printf '%s %s %sC\n' "$(basename "$z")" "$type" "$((temp/1000))"
+  done
+
+  if command -v sensors >/dev/null 2>&1; then
+    echo '-- sensors --'
+    sensors 2>/dev/null | sed -n '1,120p'
+  fi
+
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    echo '-- nvidia --'
+    nvidia-smi --query-gpu=name,pstate,temperature.gpu,power.draw,utilization.gpu,memory.used --format=csv 2>&1
+  fi
+
+  echo '-- top cpu --'
+  ps -eo pid,ppid,stat,pcpu,pmem,comm,args --sort=-pcpu | head -15
+
+  echo '-- top mem --'
+  ps -eo pid,ppid,stat,pcpu,pmem,comm,args --sort=-pmem | head -15
+
+  echo '-- recent kernel warnings/errors --'
+  journalctl -k -p warning..alert --since '5 minutes ago' --no-pager 2>/dev/null | tail -80
+
+  echo
+} >> "$LOG"
+EOF
+sudo chmod 0755 /usr/local/sbin/hang-health-snapshot
+
+sudo tee /etc/systemd/system/hang-health-snapshot.service >/dev/null <<'EOF'
+[Unit]
+Description=Collect a health snapshot for debugging hangs
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/hang-health-snapshot
+EOF
+
+sudo tee /etc/systemd/system/hang-health-snapshot.timer >/dev/null <<'EOF'
+[Unit]
+Description=Run hang health snapshot every minute
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1min
+AccuracySec=10s
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+printf 'Ensuring persistent journald storage...\n'
+sudo mkdir -p /var/log/journal
+sudo systemd-tmpfiles --create --prefix /var/log/journal || true
+
+printf 'Enabling SysRq for emergency diagnostics/reboot...\n'
+echo 'kernel.sysrq = 1' | sudo tee /etc/sysctl.d/99-sysrq.conf >/dev/null
+sudo sysctl -p /etc/sysctl.d/99-sysrq.conf >/dev/null || true
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now hang-health-snapshot.timer
+sudo systemctl start hang-health-snapshot.service || true
+
+printf '\nDone. Logs will be written to:\n  /var/log/hang-health.log\n\nCheck timer with:\n  systemctl status hang-health-snapshot.timer\n\nIf it hard-hangs again, after reboot inspect:\n  journalctl -b -1 -p warning..alert\n  tail -300 /var/log/hang-health.log\n'

--- a/laptop/x13-flow/setup-lid-ignore.sh
+++ b/laptop/x13-flow/setup-lid-ignore.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONF_DIR="/etc/systemd/logind.conf.d"
+CONF_FILE="$CONF_DIR/zz-lid-server.conf"
+
+printf 'Configuring logind to ignore laptop lid close for server/headless mode...\n'
+
+sudo install -d -m 0755 "$CONF_DIR"
+
+sudo tee "$CONF_FILE" >/dev/null <<'EOF'
+[Login]
+# Server/headless mode: keep the machine awake when the lid is closed.
+HandleLidSwitch=ignore
+HandleLidSwitchDocked=ignore
+HandleLidSwitchExternalPower=ignore
+EOF
+
+# Remove older script-created files if present. Ignore failures because this
+# is only cleanup and they may not exist.
+sudo rm -f "$CONF_DIR/lid-server.conf" "$CONF_DIR/99-lid-server.conf"
+
+printf 'Installed: %s\n' "$CONF_FILE"
+printf '\nEffective lid-related config files:\n'
+grep -R "^HandleLidSwitch" /etc/systemd/logind.conf "$CONF_DIR" 2>/dev/null || true
+
+printf '\nRestarting systemd-logind to apply changes...\n'
+printf 'Warning: this can disrupt local graphical/login sessions. SSH usually survives, but have physical access if possible.\n'
+sudo systemctl restart systemd-logind
+
+printf '\nDone. Lid close should now be ignored.\n'
+printf 'Verify later with:\n'
+printf '  grep -R "^HandleLidSwitch" /etc/systemd/logind.conf /etc/systemd/logind.conf.d 2>/dev/null\n'

--- a/laptop/x13-flow/setup-nvme-health-monitoring.sh
+++ b/laptop/x13-flow/setup-nvme-health-monitoring.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="${LOG_FILE:-/var/log/nvme-health.log}"
+DEVICE_SMARTCTL="${DEVICE_SMARTCTL:-/dev/nvme0n1}"
+DEVICE_NVME="${DEVICE_NVME:-/dev/nvme0}"
+
+printf 'Installing daily NVMe health monitoring...\n'
+
+sudo install -d -m 0755 /usr/local/sbin
+
+sudo tee /usr/local/sbin/nvme-health-snapshot >/dev/null <<EOF
+#!/usr/bin/env bash
+set +e
+
+LOG_FILE="$LOG_FILE"
+DEVICE_SMARTCTL="$DEVICE_SMARTCTL"
+DEVICE_NVME="$DEVICE_NVME"
+
+{
+  echo '===== nvme health snapshot' "\$(date --iso-8601=seconds)" '====='
+  echo '-- devices --'
+  lsblk -o NAME,TYPE,SIZE,MODEL,SERIAL,TRAN,MOUNTPOINTS 2>&1
+  echo
+
+  echo '-- smartctl summary --'
+  if command -v smartctl >/dev/null 2>&1; then
+    smartctl -H "\$DEVICE_SMARTCTL" 2>&1
+    echo
+    smartctl -a "\$DEVICE_SMARTCTL" 2>&1 | sed -n '/SMART overall-health/,/Error Information/p; /Critical Warning/p; /Temperature:/p; /Available Spare:/p; /Percentage Used:/p; /Data Units Read:/p; /Data Units Written:/p; /Host Read Commands:/p; /Host Write Commands:/p; /Controller Busy Time:/p; /Power Cycles:/p; /Power On Hours:/p; /Unsafe Shutdowns:/p; /Media and Data Integrity Errors:/p; /Error Information Log Entries:/p'
+  else
+    echo 'smartctl not installed. Install smartmontools for SMART health details.'
+  fi
+  echo
+
+  echo '-- nvme smart-log --'
+  if command -v nvme >/dev/null 2>&1; then
+    nvme smart-log "\$DEVICE_NVME" 2>&1
+  else
+    echo 'nvme CLI not installed. Install nvme-cli for NVMe smart-log details.'
+  fi
+  echo
+
+  echo '-- recent nvme/kernel storage warnings, last 24h --'
+  journalctl -k --since '24 hours ago' --no-pager 2>/dev/null \
+    | grep -Ei 'nvme|I/O error|blk_update_request|timeout|reset|abort|media error|critical warning' \
+    | tail -200 || true
+  echo
+} >> "\$LOG_FILE"
+EOF
+
+sudo chmod 0755 /usr/local/sbin/nvme-health-snapshot
+
+sudo tee /etc/systemd/system/nvme-health-snapshot.service >/dev/null <<'EOF'
+[Unit]
+Description=Collect daily NVMe SMART health snapshot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/nvme-health-snapshot
+EOF
+
+sudo tee /etc/systemd/system/nvme-health-snapshot.timer >/dev/null <<'EOF'
+[Unit]
+Description=Run daily NVMe SMART health snapshot
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1d
+AccuracySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+sudo touch "$LOG_FILE"
+sudo chmod 0644 "$LOG_FILE"
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now nvme-health-snapshot.timer
+sudo systemctl start nvme-health-snapshot.service || true
+
+printf '\nDone. Daily NVMe health snapshots will be written to:\n  %s\n' "$LOG_FILE"
+printf '\nCheck status with:\n  systemctl status nvme-health-snapshot.timer\n'
+printf '\nRead latest snapshots with:\n  tail -200 %s\n' "$LOG_FILE"
+printf '\nIf output says tools are missing, install them with:\n  sudo apt install smartmontools nvme-cli\n'

--- a/laptop/x13-flow/setup-panic-on-oops.sh
+++ b/laptop/x13-flow/setup-panic-on-oops.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'Installing kernel oops auto-reboot sysctl config...\n'
+
+sudo tee /etc/sysctl.d/99-panic-on-oops.conf >/dev/null <<'EOF'
+# Reboot automatically if the kernel hits an oops/panic.
+# This is intended for headless/server use so the machine does not remain
+# unreachable over SSH indefinitely after kernel memory corruption.
+kernel.panic_on_oops = 1
+kernel.panic = 30
+EOF
+
+sudo sysctl --system
+
+printf '\nDone. Current values:\n'
+sysctl kernel.panic_on_oops kernel.panic

--- a/laptop/x13-flow/setup-reboot-investigation.sh
+++ b/laptop/x13-flow/setup-reboot-investigation.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INSTALL_KDUMP="${INSTALL_KDUMP:-0}"
+PSTORE_ARCHIVE_DIR="${PSTORE_ARCHIVE_DIR:-/var/log/pstore-archive}"
+
+printf 'Installing sudden-reboot investigation tooling...\n'
+
+printf '\n[1/5] Enabling stronger panic/reboot sysctls...\n'
+sudo tee /etc/sysctl.d/98-reboot-investigation.conf >/dev/null <<'EOF'
+# Reboot automatically after kernel failures so a headless machine does not stay wedged.
+# These settings are intentionally diagnostic/mitigation-oriented.
+kernel.panic = 30
+kernel.panic_on_oops = 1
+kernel.softlockup_panic = 1
+kernel.hung_task_panic = 1
+kernel.panic_on_warn = 0
+EOF
+sudo sysctl --system >/dev/null
+sysctl kernel.panic kernel.panic_on_oops kernel.softlockup_panic kernel.hung_task_panic kernel.panic_on_warn
+
+printf '\n[2/5] Ensuring pstore is mounted when available...\n'
+sudo install -d -m 0755 /sys/fs/pstore || true
+if ! mountpoint -q /sys/fs/pstore; then
+  sudo mount -t pstore pstore /sys/fs/pstore 2>/dev/null || true
+fi
+if mountpoint -q /sys/fs/pstore; then
+  printf 'pstore is mounted at /sys/fs/pstore\n'
+else
+  printf 'WARNING: pstore is not mounted/available. Firmware may not expose EFI pstore/ramoops.\n' >&2
+fi
+
+printf '\n[3/5] Installing pstore archive service...\n'
+sudo install -d -m 0755 /usr/local/sbin "$PSTORE_ARCHIVE_DIR"
+sudo tee /usr/local/sbin/archive-pstore >/dev/null <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+src=/sys/fs/pstore
+dst="$PSTORE_ARCHIVE_DIR"
+
+[ -d "\$src" ] || exit 0
+mkdir -p "\$dst"
+
+if ! find "\$src" -mindepth 1 -maxdepth 1 -type f -print -quit | grep -q .; then
+  exit 0
+fi
+
+stamp="\$(date --iso-8601=seconds | tr ':' '-')"
+out="\$dst/\$stamp"
+mkdir -p "\$out"
+cp -a "\$src"/* "\$out"/ 2>/dev/null || true
+
+# Keep a lightweight index for quick post-reboot checks.
+{
+  echo "===== pstore archive \$stamp ====="
+  find "\$out" -maxdepth 1 -type f -printf '%f %s bytes\\n' | sort
+  echo
+} >> "\$dst/index.log"
+EOF
+sudo chmod 0755 /usr/local/sbin/archive-pstore
+
+sudo tee /etc/systemd/system/archive-pstore.service >/dev/null <<'EOF'
+[Unit]
+Description=Archive pstore crash logs after boot
+DefaultDependencies=no
+After=sysinit.target
+Before=multi-user.target
+ConditionPathExists=/sys/fs/pstore
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/archive-pstore
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable archive-pstore.service >/dev/null
+sudo systemctl start archive-pstore.service || true
+printf 'pstore archives will be saved under: %s\n' "$PSTORE_ARCHIVE_DIR"
+
+printf '\n[4/5] De-phasing x13 screen keep-off timer if installed...\n'
+if systemctl list-unit-files x13-screen-off.timer >/dev/null 2>&1; then
+  sudo install -d -m 0755 /etc/systemd/system/x13-screen-off.timer.d
+  sudo tee /etc/systemd/system/x13-screen-off.timer.d/10-dephase.conf >/dev/null <<'EOF'
+[Timer]
+# Avoid running at the exact same second as hang-health-snapshot.timer.
+OnBootSec=
+OnUnitActiveSec=
+AccuracySec=
+OnBootSec=45s
+OnUnitActiveSec=65s
+AccuracySec=5s
+EOF
+  sudo systemctl daemon-reload
+  if systemctl is-enabled x13-screen-off.timer >/dev/null 2>&1; then
+    sudo systemctl restart x13-screen-off.timer || true
+  fi
+  printf 'x13-screen-off.timer now runs offset from hang-health-snapshot.timer.\n'
+else
+  printf 'x13-screen-off.timer not installed; skipping.\n'
+fi
+
+printf '\n[5/5] Optional kdump/crash dump setup...\n'
+if [[ "$INSTALL_KDUMP" == "1" ]]; then
+  sudo apt-get update
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y linux-crashdump kdump-tools
+  printf 'kdump packages installed. Review /etc/default/kdump-tools and reboot when convenient.\n'
+else
+  printf 'Skipping kdump install by default. To install it, rerun with:\n'
+  printf '  INSTALL_KDUMP=1 %s\n' "$0"
+fi
+
+printf '\nQuick hardware/firmware commands to run manually if reboots continue:\n'
+printf '  sudo smartctl -a /dev/nvme0n1\n'
+printf '  fwupdmgr get-updates\n'
+printf '  memtest86+ / firmware memory diagnostics overnight\n'
+
+printf '\nDone. After the next unexpected reboot, check:\n'
+printf '  sudo find %s -maxdepth 2 -type f -print\n' "$PSTORE_ARCHIVE_DIR"
+printf '  sudo grep -R . %s /sys/fs/pstore 2>/dev/null | less\n' "$PSTORE_ARCHIVE_DIR"
+printf '  journalctl -b -1 -k --no-pager | tail -300\n'


### PR DESCRIPTION
## Summary
- add X13 Flow laptop management scripts copied from dotfiles-qtile
- preserve/update RCA notes with the July 7 unclean reboot evidence
- add setup helpers for screen keep-off, panic/reboot investigation, lid-ignore, and NVMe health monitoring

## Validation
- bash -n laptop/x13-flow/*.sh
- python3 -m py_compile laptop/x13-flow/stats.py
