### PR TITLE
Add env diff and AI usage helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ myClippings.txt
 *.temp
 clippings.json
 highlight-manager-broken.sh
+.ai-usage-cache/
 
 *.json
 *.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ myClippings.txt
 clippings.json
 highlight-manager-broken.sh
 .ai-usage-cache/
+ai-usage.html
 
 *.json
 *.tsv

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ clippings.json
 highlight-manager-broken.sh
 .ai-usage-cache/
 ai-usage.html
+ai-usage.hosts
 
 *.json
 *.tsv

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[audible-download.sh](docs/audible-download.md)** - Bulk download audiobooks from Audible with filtering options
 
 ### Development Tools
-- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect ccusage-backed AI coding stats from local/SSH hosts into cached JSON/CSV and a static dashboard with date/host filters, heatmaps, and tokenmaxxing metrics
+- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect ccusage-backed AI coding stats from local/SSH hosts in parallel into append-only per-host ledgers, JSON/CSV, and an offline-capable responsive dashboard with host/date filters, sortable model table, heatmaps, and tokenmaxxing metrics
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[audible-download.sh](docs/audible-download.md)** - Bulk download audiobooks from Audible with filtering options
 
 ### Development Tools
-- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect ccusage-backed AI coding stats from local/SSH hosts into cached JSON/CSV and a static dashboard with date ranges and tokenmaxxing metrics
+- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect ccusage-backed AI coding stats from local/SSH hosts into cached JSON/CSV and a static dashboard with date/host filters, heatmaps, and tokenmaxxing metrics
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 
 ### Development Tools
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
+- **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
 - **[highlight-manager.sh](docs/highlight-manager.md)** - Manage Kindle highlights with DuckDB storage and beautiful terminal display
 
@@ -46,6 +47,10 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 ./check-pr.sh --concise  # Show only summary and items needing attention
 ./check-pr.sh /path/to/repo  # Check a PR from another repository directory
 
+# Diff env files without printing token-like values
+./env-diff.sh .env .env.example
+./env-diff.sh --all .env.local .env.production
+
 # Generate .gitignore for Python project
 ./gi-select.sh  # Interactive selection
 
@@ -73,6 +78,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 | audiobook-split | `ffmpeg`, `gum` |
 | audible-download | `uvx`, `audible-cli`, `gum` |
 | check-pr | `uv`, `gh`, `git` |
+| env-diff | `gum`, `awk`, `sort` |
 | gi-select | `gum`, gitignore repository |
 | highlight-manager | `duckdb`, `gum`, `jq`, `python3` |
 | simple-notify | `curl` |
@@ -116,6 +122,7 @@ docs/
 ├── audiobook-pipeline.md    # Complete audiobook processing
 ├── audiobook-split.md       # Audio segmentation
 ├── audible-download.md      # Audible bulk downloads
+├── env-diff.md             # Secret-safe env file diffing
 ├── gi-select.md            # Interactive gitignore generation
 ├── highlight-manager.md     # Kindle highlights management
 ├── simple-notify.md        # Simplepush notifications

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[audible-download.sh](docs/audible-download.md)** - Bulk download audiobooks from Audible with filtering options
 
 ### Development Tools
-- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect Claude Code, Codex, pi, opencode, and Grok usage from local/SSH hosts into cached JSON and CSV stats
+- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect Claude Code, Codex, pi, opencode, and Grok usage from local/SSH hosts into cached JSON/CSV stats and a static HTML dashboard
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
@@ -48,7 +48,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 ./check-pr.sh --concise  # Show only summary and items needing attention
 ./check-pr.sh /path/to/repo  # Check a PR from another repository directory
 
-# Collect AI coding-agent usage into raw and daily JSON/CSV stats
+# Collect AI coding-agent usage into raw/daily JSON/CSV stats and ai-usage.html
 ./ai-usage-collect.py
 ./ai-usage-collect.py --host eqr5 --host macbook=stone@macbook.local
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[audible-download.sh](docs/audible-download.md)** - Bulk download audiobooks from Audible with filtering options
 
 ### Development Tools
-- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect Claude Code, Codex, pi, opencode, and Grok usage from local/SSH hosts into cached JSON/CSV stats and a static HTML dashboard
+- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect ccusage-backed AI coding stats from local/SSH hosts into cached JSON/CSV and a static dashboard with date ranges and tokenmaxxing metrics
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
@@ -82,7 +82,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 | audiobook-pipeline | `uvx`, `audible-cli`, `ffmpeg`, `gum` |
 | audiobook-split | `ffmpeg`, `gum` |
 | audible-download | `uvx`, `audible-cli`, `gum` |
-| ai-usage-collect | `python3`, `ssh` for remote hosts, `ccusage`/`npx` for Claude cost data |
+| ai-usage-collect | `python3`, `ssh` for remote hosts, `ccusage`/`npx` for unified usage and cost data |
 | check-pr | `uv`, `gh`, `git` |
 | env-diff | `gum`, `awk`, `sort` |
 | gi-select | `gum`, gitignore repository |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[audible-download.sh](docs/audible-download.md)** - Bulk download audiobooks from Audible with filtering options
 
 ### Development Tools
+- **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect Claude Code, Codex, pi, opencode, and Grok usage from local/SSH hosts into cached JSON and CSV stats
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
@@ -47,6 +48,10 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 ./check-pr.sh --concise  # Show only summary and items needing attention
 ./check-pr.sh /path/to/repo  # Check a PR from another repository directory
 
+# Collect AI coding-agent usage into raw and daily JSON/CSV stats
+./ai-usage-collect.py
+./ai-usage-collect.py --host eqr5 --host macbook=stone@macbook.local
+
 # Diff env files without printing token-like values
 ./env-diff.sh .env .env.example
 ./env-diff.sh --all .env.local .env.production
@@ -77,6 +82,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 | audiobook-pipeline | `uvx`, `audible-cli`, `ffmpeg`, `gum` |
 | audiobook-split | `ffmpeg`, `gum` |
 | audible-download | `uvx`, `audible-cli`, `gum` |
+| ai-usage-collect | `python3`, `ssh` for remote hosts, `ccusage`/`npx` for Claude cost data |
 | check-pr | `uv`, `gh`, `git` |
 | env-diff | `gum`, `awk`, `sort` |
 | gi-select | `gum`, gitignore repository |
@@ -122,6 +128,7 @@ docs/
 ├── audiobook-pipeline.md    # Complete audiobook processing
 ├── audiobook-split.md       # Audio segmentation
 ├── audible-download.md      # Audible bulk downloads
+├── ai-usage-collect.md      # AI coding-agent usage collection
 ├── env-diff.md             # Secret-safe env file diffing
 ├── gi-select.md            # Interactive gitignore generation
 ├── highlight-manager.md     # Kindle highlights management

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -835,8 +835,17 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .panel { border-top: 1px solid var(--rule-strong); padding-top: 14px; min-width: 0; }
 .flow-panel { overflow: hidden; padding-bottom: 8px; }
 .panel h2 { margin: 0 0 14px; font-size: 22px; font-weight: 500; letter-spacing: -.02em; }
-.chart { display: flex; align-items: flex-end; gap: 3px; height: 230px; padding: 10px 0 0; border-bottom: 1px solid var(--rule); }
-.day { flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
+.chart-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+.chart-head h2 { margin: 0; }
+.scale-control { display: flex; align-items: center; gap: 8px; color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; text-transform: uppercase; letter-spacing: .12em; }
+.scale-control select { color: var(--ink); background: var(--paper); border: 1px solid var(--rule); padding: 6px 8px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.chart-body { display: grid; grid-template-columns: 58px minmax(0, 1fr); gap: 10px; align-items: start; }
+.chart-stack { min-width: 0; }
+.y-axis { position: relative; height: 230px; border-bottom: 1px solid transparent; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.y-tick { position: absolute; right: 0; transform: translateY(50%); white-space: nowrap; }
+.chart { position: relative; display: flex; align-items: flex-end; gap: 3px; height: 230px; padding: 10px 0 0; border-bottom: 1px solid var(--rule); }
+.gridline { position: absolute; left: 0; right: 0; border-top: 1px solid rgba(237,228,209,.08); z-index: 0; }
+.day { position: relative; z-index: 1; flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
 .day:hover { outline: 1px solid var(--gold); outline-offset: 2px; opacity: 1; }
 .seg.in { background: var(--in); } .seg.out { background: var(--out); } .seg.cw { background: var(--cw); } .seg.cr { background: var(--cr); } .seg.rz { background: var(--rz); }
 .chart-axis { position: relative; height: 22px; margin: 8px 0 12px; overflow: hidden; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
@@ -907,9 +916,17 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
   </section>
   <section class="grid">
     <div class="panel flow-panel">
-      <h2>Daily Token Flow</h2>
-      <div id="chart" class="chart" aria-label="Daily token bars"></div>
-      <div id="chartAxis" class="chart-axis" aria-label="Daily token date axis"></div>
+      <div class="chart-head">
+        <h2>Daily Token Flow</h2>
+        <label class="scale-control">Y scale <select id="tokenScale"><option value="log" selected>Log</option><option value="linear">Linear</option></select></label>
+      </div>
+      <div class="chart-body">
+        <div id="yAxis" class="y-axis" aria-label="Daily token y axis"></div>
+        <div class="chart-stack">
+          <div id="chart" class="chart" aria-label="Daily token bars"></div>
+          <div id="chartAxis" class="chart-axis" aria-label="Daily token date axis"></div>
+        </div>
+      </div>
       <div class="legend">
         <span><i class="swatch" style="background:var(--in)"></i>input</span>
         <span><i class="swatch" style="background:var(--out)"></i>output</span>
@@ -961,7 +978,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 const D = JSON.parse(document.getElementById('usage-data').textContent);
 const fields = ['input_tokens','output_tokens','cache_creation_tokens','cache_read_tokens','reasoning_tokens'];
 const segClass = ['in','out','cw','cr','rz'];
-let state = { from: null, to: null, preset: 'all', hosts: ['all'] };
+let state = { from: null, to: null, preset: 'all', hosts: ['all'], tokenScale: 'log' };
 function fmt(n) { n = Number(n || 0); if (n >= 1e9) return (n/1e9).toFixed(1)+'B'; if (n >= 1e6) return (n/1e6).toFixed(1)+'M'; if (n >= 1e3) return (n/1e3).toFixed(0)+'k'; return String(Math.round(n)); }
 function usd(n) { return '$' + Number(n || 0).toFixed(2); }
 function pct(n) { return Number(n || 0).toFixed(1) + '%'; }
@@ -1009,6 +1026,39 @@ function dateLabel(date) {
   const parsed = new Date(date + 'T00:00:00Z');
   return parsed.toLocaleDateString('en', {month: 'short', day: 'numeric', timeZone: 'UTC'});
 }
+function scaleRatio(value, max) {
+  value = Number(value || 0); max = Number(max || 0);
+  if (!value || !max) return 0;
+  if (state.tokenScale === 'log') return Math.log10(value + 1) / Math.log10(max + 1);
+  return value / max;
+}
+function yTicks(max) {
+  max = Number(max || 0);
+  if (!max) return [0];
+  if (state.tokenScale === 'log') {
+    const ticks = [0];
+    let value = 1;
+    while (value < max) { ticks.push(value); value *= 10; }
+    if (!ticks.includes(max)) ticks.push(max);
+    return ticks.filter((value, index, arr) => index === 0 || value === max || value >= max / 100000 || arr.length <= 7).slice(-7);
+  }
+  return [0, .25, .5, .75, 1].map(ratio => Math.round(max * ratio));
+}
+function renderYAxis(max) {
+  const axis = clear('yAxis');
+  const chart = document.getElementById('chart');
+  chart.querySelectorAll('.gridline').forEach(line => line.remove());
+  yTicks(max).forEach(value => {
+    const ratio = scaleRatio(value, max);
+    const bottom = Math.max(0, Math.min(100, ratio * 100));
+    const tick = node('span', 'y-tick', fmt(value));
+    tick.style.bottom = bottom + '%';
+    axis.append(tick);
+    const line = node('i', 'gridline');
+    line.style.bottom = bottom + '%';
+    chart.append(line);
+  });
+}
 function renderChartAxis(days) {
   const axis = clear('chartAxis');
   if (!days.length) return;
@@ -1026,10 +1076,19 @@ function renderChartAxis(days) {
 function renderChart(days) {
   const root = clear('chart');
   const max = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
+  renderYAxis(max);
   days.forEach(d => {
+    const total = Number(d.total_tokens || 0);
+    const scaledTotal = scaleRatio(total, max) * 100;
     const day = node('div','day');
-    day.title = `${d.date} · ${fmt(d.total_tokens)} tokens · ${usd(d.cost_usd)}`;
-    fields.forEach((f, idx) => { const seg = node('div', 'seg ' + segClass[idx]); const height = Math.max(0, Number(d[f] || 0) / max * 100); seg.style.height = height ? Math.max(.8, height) + '%' : '0'; day.append(seg); });
+    day.title = `${d.date} · ${fmt(total)} tokens · ${usd(d.cost_usd)} · ${state.tokenScale} scale`;
+    fields.forEach((f, idx) => {
+      const seg = node('div', 'seg ' + segClass[idx]);
+      const share = total ? Number(d[f] || 0) / total : 0;
+      const height = scaledTotal * share;
+      seg.style.height = height ? Math.max(.8, height) + '%' : '0';
+      day.append(seg);
+    });
     root.append(day);
   });
   renderChartAxis(days);
@@ -1194,6 +1253,10 @@ function applyHostFilter() {
   }
   renderAll();
 }
+function applyTokenScale() {
+  state.tokenScale = document.getElementById('tokenScale').value || 'log';
+  renderAll();
+}
 function renderAll() {
   const derived = derive(selectedRows());
   renderStats(derived.summary); renderChart(derived.days); renderCost(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderHeatmaps(derived.days); renderModels(derived.models); renderHosts();
@@ -1205,6 +1268,7 @@ document.querySelectorAll('#presets button').forEach(button => button.addEventLi
 document.getElementById('fromDate').addEventListener('change', applyCustomRange);
 document.getElementById('toDate').addEventListener('change', applyCustomRange);
 document.getElementById('hostFilter').addEventListener('change', applyHostFilter);
+document.getElementById('tokenScale').addEventListener('change', applyTokenScale);
 populateHostFilter();
 applyRange('all');
 </script>

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -11,6 +11,7 @@ import argparse
 import csv
 import datetime as dt
 import glob
+import html
 import json
 import os
 import platform
@@ -32,6 +33,7 @@ DEFAULT_JSON = "ai-usage.json"
 DEFAULT_CSV = "ai-usage.csv"
 DEFAULT_DAILY_JSON = "ai-usage-daily.json"
 DEFAULT_DAILY_CSV = "ai-usage-daily.csv"
+DEFAULT_HTML = "ai-usage.html"
 
 
 @dataclass
@@ -862,6 +864,352 @@ def write_daily_csv(path: Path, records: list[dict[str, Any]]) -> None:
             writer.writerow(record)
 
 
+def json_for_script(payload: Any) -> str:
+    return json.dumps(payload, separators=(",", ":"), sort_keys=True).replace("</", "<\\/")
+
+
+def html_escape(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def add_to_bucket(bucket: dict[str, Any], record: dict[str, Any]) -> None:
+    bucket["records"] = as_int(bucket.get("records")) + as_int(record.get("records", 1))
+    bucket["sessions"] = as_int(bucket.get("sessions")) + as_int(record.get("sessions", 0))
+    for field in (
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "reasoning_tokens",
+        "total_tokens",
+    ):
+        bucket[field] = as_int(bucket.get(field)) + as_int(record.get(field))
+    bucket["cost_usd"] = as_float(bucket.get("cost_usd")) + as_float(record.get("cost_usd"))
+
+
+def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> dict[str, Any]:
+    day_buckets: dict[str, dict[str, Any]] = {}
+    model_buckets: dict[tuple[str, str, str], dict[str, Any]] = {}
+    service_buckets: dict[tuple[str, str], dict[str, Any]] = {}
+    hosts_seen: set[str] = set()
+    accounts_seen: set[str] = set()
+
+    for record in daily:
+        date = str(record.get("date") or "")
+        if date:
+            day_bucket = day_buckets.setdefault(
+                date,
+                {
+                    "date": date,
+                    "records": 0,
+                    "sessions": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_creation_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "total_tokens": 0,
+                    "cost_usd": 0.0,
+                },
+            )
+            add_to_bucket(day_bucket, record)
+
+        service = str(record.get("service") or record.get("source") or "unknown")
+        source = str(record.get("source") or "unknown")
+        provider = str(record.get("provider") or "")
+        model = str(record.get("model") or "unknown")
+        model_key = (service, provider, model)
+        model_bucket = model_buckets.setdefault(
+            model_key,
+            {
+                "service": service,
+                "provider": provider,
+                "model": model,
+                "records": 0,
+                "sessions": 0,
+                "days": set(),
+                "sources": set(),
+                "hosts": set(),
+                "accounts": set(),
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cache_read_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+            },
+        )
+        add_to_bucket(model_bucket, record)
+        if date:
+            model_bucket["days"].add(date)
+        model_bucket["sources"].add(source)
+
+        for host in str(record.get("hosts") or record.get("host") or "").split(","):
+            if host and host != "all":
+                model_bucket["hosts"].add(host)
+                hosts_seen.add(host)
+        for account in str(record.get("accounts") or record.get("account_label") or "").split(","):
+            if account and account != "all":
+                model_bucket["accounts"].add(account)
+                accounts_seen.add(account)
+
+        service_key = (source, service)
+        service_bucket = service_buckets.setdefault(
+            service_key,
+            {
+                "source": source,
+                "service": service,
+                "records": 0,
+                "sessions": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cache_read_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+            },
+        )
+        add_to_bucket(service_bucket, record)
+
+    days = sorted(day_buckets.values(), key=lambda item: item["date"])
+    models = []
+    for bucket in model_buckets.values():
+        item = dict(bucket)
+        item["days"] = len(bucket["days"])
+        item["sources"] = sorted(bucket["sources"])
+        item["hosts"] = sorted(bucket["hosts"])
+        item["accounts"] = sorted(bucket["accounts"])
+        item["cost_usd"] = round(item["cost_usd"], 6)
+        models.append(item)
+    models.sort(key=lambda item: item["total_tokens"], reverse=True)
+
+    services = []
+    for bucket in service_buckets.values():
+        item = dict(bucket)
+        item["cost_usd"] = round(item["cost_usd"], 6)
+        services.append(item)
+    services.sort(key=lambda item: item["total_tokens"], reverse=True)
+
+    totals = {
+        "records": sum(as_int(day.get("records")) for day in days),
+        "sessions": sum(as_int(day.get("sessions")) for day in days),
+        "input_tokens": sum(as_int(day.get("input_tokens")) for day in days),
+        "output_tokens": sum(as_int(day.get("output_tokens")) for day in days),
+        "cache_creation_tokens": sum(as_int(day.get("cache_creation_tokens")) for day in days),
+        "cache_read_tokens": sum(as_int(day.get("cache_read_tokens")) for day in days),
+        "reasoning_tokens": sum(as_int(day.get("reasoning_tokens")) for day in days),
+        "total_tokens": sum(as_int(day.get("total_tokens")) for day in days),
+        "cost_usd": round(sum(as_float(day.get("cost_usd")) for day in days), 6),
+        "active_models": len(models),
+        "latest_date": days[-1]["date"] if days else "",
+        "first_date": days[0]["date"] if days else "",
+        "hosts": len(hosts_seen),
+        "accounts": len(accounts_seen),
+    }
+
+    return {
+        "generated_at": combined.get("generated_at") or utc_now(),
+        "summary": totals,
+        "days": days,
+        "models": models[:30],
+        "services": services,
+        "hosts": combined.get("statuses", []),
+    }
+
+
+HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AI Usage Ledger</title>
+<style>
+:root {
+  --paper: #15130f;
+  --ink: #ede4d1;
+  --muted: #9d927f;
+  --rule: #343025;
+  --rule-strong: #5a4d35;
+  --gold: #d8a33d;
+  --green: #77b77a;
+  --red: #d66b55;
+  --in: #d7e7e0;
+  --out: #8fb8b6;
+  --cw: #577f86;
+  --cr: #314f62;
+  --rz: #7d6c9f;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 12% 8%, rgba(216, 163, 61, .11), transparent 28rem),
+    linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px),
+    var(--paper);
+  background-size: auto, 44px 44px, auto;
+  font-family: Georgia, "Times New Roman", serif;
+}
+main { width: min(1220px, calc(100vw - 32px)); margin: 0 auto; padding: 34px 0 44px; }
+.mast { border-bottom: 1px solid var(--rule-strong); padding-bottom: 18px; display: flex; justify-content: space-between; gap: 20px; }
+h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spacing: -.05em; font-weight: 500; }
+.kicker, .label, th { color: var(--muted); font: 11px/1.2 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: .14em; text-transform: uppercase; }
+.generated { text-align: right; align-self: end; max-width: 360px; }
+.stats { display: grid; grid-template-columns: repeat(8, minmax(0, 1fr)); border-bottom: 1px solid var(--rule); }
+.stat { padding: 18px 14px 16px; border-right: 1px solid var(--rule); min-width: 0; }
+.stat:last-child { border-right: 0; }
+.value { font: 29px/.95 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: -.05em; white-space: nowrap; }
+.grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 28px; margin-top: 30px; }
+.panel { border-top: 1px solid var(--rule-strong); padding-top: 14px; min-width: 0; }
+.panel h2 { margin: 0 0 14px; font-size: 22px; font-weight: 500; letter-spacing: -.02em; }
+.chart { display: flex; align-items: flex-end; gap: 3px; height: 230px; padding: 10px 0 0; border-bottom: 1px solid var(--rule); }
+.day { flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
+.day:hover { outline: 1px solid var(--gold); outline-offset: 2px; opacity: 1; }
+.seg.in { background: var(--in); } .seg.out { background: var(--out); } .seg.cw { background: var(--cw); } .seg.cr { background: var(--cr); } .seg.rz { background: var(--rz); }
+.legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 10px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.swatch { display: inline-block; width: 10px; height: 10px; margin-right: 5px; vertical-align: -1px; }
+.costline { width: 100%; height: 74px; margin-top: 8px; overflow: visible; }
+.servicebar { display: flex; height: 32px; border: 1px solid var(--rule); margin-bottom: 12px; }
+.servicebit { min-width: 2px; }
+.service-list { display: grid; gap: 8px; }
+.service-row { display: grid; grid-template-columns: 1fr auto; gap: 12px; font: 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
+table { width: 100%; border-collapse: collapse; font: 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+th, td { padding: 10px 8px; border-bottom: 1px solid var(--rule); vertical-align: top; }
+th { text-align: left; }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+.model-name { color: var(--ink); font-family: Georgia, "Times New Roman", serif; font-size: 15px; }
+.meta { color: var(--muted); font-size: 11px; margin-top: 3px; }
+.hosts { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+.host { border: 1px solid var(--rule); padding: 7px 9px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
+.host.updated .dot { color: var(--green); } .host.cached .dot { color: var(--gold); } .host.missing .dot { color: var(--red); }
+.note { color: var(--muted); font-size: 13px; line-height: 1.45; margin-top: 12px; }
+@media (max-width: 900px) { .mast, .grid { display: block; } .generated { text-align: left; margin-top: 14px; } .stats { grid-template-columns: repeat(2, 1fr); } .stat:nth-child(2n) { border-right: 0; } }
+</style>
+</head>
+<body>
+<main>
+  <header class="mast">
+    <div><div class="kicker">Personal instrument panel</div><h1>AI Usage<br>Ledger</h1></div>
+    <div class="generated"><div class="label">Generated</div><div id="generated"></div><p class="note">Accounts are merged by default. Cost is reported only when the source provides it.</p></div>
+  </header>
+  <section class="stats" id="stats" aria-label="Summary statistics"></section>
+  <section class="grid">
+    <div class="panel">
+      <h2>Daily Token Flow</h2>
+      <div id="chart" class="chart" aria-label="Daily token bars"></div>
+      <div class="legend">
+        <span><i class="swatch" style="background:var(--in)"></i>input</span>
+        <span><i class="swatch" style="background:var(--out)"></i>output</span>
+        <span><i class="swatch" style="background:var(--cw)"></i>cache write</span>
+        <span><i class="swatch" style="background:var(--cr)"></i>cache read</span>
+        <span><i class="swatch" style="background:var(--rz)"></i>reasoning</span>
+      </div>
+      <svg id="costline" class="costline" viewBox="0 0 1000 74" preserveAspectRatio="none" aria-label="Daily cost line"></svg>
+    </div>
+    <aside class="panel">
+      <h2>Service Mix</h2>
+      <div id="servicebar" class="servicebar"></div>
+      <div id="services" class="service-list"></div>
+      <p class="note">The service field is inferred from provider/model names, so Grok used through pi is counted as Grok while retaining source=pi.</p>
+    </aside>
+  </section>
+  <section class="panel" style="margin-top:30px">
+    <h2>Top Models</h2>
+    <table>
+      <thead><tr><th>Model</th><th class="num">Days</th><th class="num">Input</th><th class="num">Output</th><th class="num">Cache</th><th class="num">Total</th><th class="num">Cost</th></tr></thead>
+      <tbody id="models"></tbody>
+    </table>
+  </section>
+  <section class="panel" style="margin-top:30px">
+    <h2>Host Cache Status</h2>
+    <div id="hosts" class="hosts"></div>
+  </section>
+</main>
+<script id="usage-data" type="application/json">__DATA__</script>
+<script>
+const D = JSON.parse(document.getElementById('usage-data').textContent);
+const fields = ['input_tokens','output_tokens','cache_creation_tokens','cache_read_tokens','reasoning_tokens'];
+const segClass = ['in','out','cw','cr','rz'];
+function fmt(n) { n = Number(n || 0); if (n >= 1e9) return (n/1e9).toFixed(1)+'B'; if (n >= 1e6) return (n/1e6).toFixed(1)+'M'; if (n >= 1e3) return (n/1e3).toFixed(0)+'k'; return String(Math.round(n)); }
+function usd(n) { return '$' + Number(n || 0).toFixed(2); }
+function node(tag, cls, text) { const el = document.createElement(tag); if (cls) el.className = cls; if (text !== undefined) el.textContent = text; return el; }
+function renderStats() {
+  document.getElementById('generated').textContent = D.generated_at || 'unknown';
+  const stats = [
+    ['total', fmt(D.summary.total_tokens)], ['input', fmt(D.summary.input_tokens)], ['output', fmt(D.summary.output_tokens)],
+    ['cache read', fmt(D.summary.cache_read_tokens)], ['cache write', fmt(D.summary.cache_creation_tokens)], ['cost', usd(D.summary.cost_usd)],
+    ['models', fmt(D.summary.active_models)], ['latest', D.summary.latest_date || 'n/a']
+  ];
+  const root = document.getElementById('stats');
+  stats.forEach(([label, value]) => { const box = node('div','stat'); box.append(node('div','label',label)); box.append(node('div','value',value)); root.append(box); });
+}
+function renderChart() {
+  const root = document.getElementById('chart');
+  const days = D.days || [];
+  const max = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
+  days.forEach(d => {
+    const day = node('div','day');
+    day.title = `${d.date} · ${fmt(d.total_tokens)} tokens · ${usd(d.cost_usd)}`;
+    fields.forEach((f, idx) => { const seg = node('div', 'seg ' + segClass[idx]); const pct = Math.max(0, Number(d[f] || 0) / max * 100); seg.style.height = pct ? Math.max(.8, pct) + '%' : '0'; day.append(seg); });
+    root.append(day);
+  });
+}
+function renderCost() {
+  const svg = document.getElementById('costline');
+  const days = D.days || [];
+  const max = Math.max(0, ...days.map(d => Number(d.cost_usd || 0)));
+  if (!days.length || !max) { const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x','0'); t.setAttribute('y','38'); t.setAttribute('fill','#9d927f'); t.textContent = 'No reported cost data'; svg.append(t); return; }
+  const points = days.map((d, i) => { const x = days.length === 1 ? 0 : i * (1000 / (days.length - 1)); const y = 62 - (Number(d.cost_usd || 0) / max * 54); return `${x.toFixed(1)},${y.toFixed(1)}`; }).join(' ');
+  const line = document.createElementNS('http://www.w3.org/2000/svg','polyline'); line.setAttribute('points', points); line.setAttribute('fill','none'); line.setAttribute('stroke','#d8a33d'); line.setAttribute('stroke-width','3'); line.setAttribute('vector-effect','non-scaling-stroke'); svg.append(line);
+  const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x','1000'); t.setAttribute('y','12'); t.setAttribute('text-anchor','end'); t.setAttribute('fill','#d8a33d'); t.textContent = 'max ' + usd(max); svg.append(t);
+}
+function renderServices() {
+  const palette = ['#d8a33d','#8fb8b6','#577f86','#7d6c9f','#d66b55','#77b77a','#ede4d1'];
+  const total = Math.max(1, D.services.reduce((sum, row) => sum + Number(row.total_tokens || 0), 0));
+  const bar = document.getElementById('servicebar');
+  const list = document.getElementById('services');
+  D.services.forEach((row, idx) => {
+    const color = palette[idx % palette.length];
+    const bit = node('div','servicebit'); bit.style.width = (Number(row.total_tokens || 0) / total * 100) + '%'; bit.style.background = color; bit.title = `${row.source}/${row.service} · ${fmt(row.total_tokens)}`; bar.append(bit);
+    const item = node('div','service-row'); const left = node('span','',`${row.source}/${row.service}`); left.style.color = color; item.append(left); item.append(node('span','',`${fmt(row.total_tokens)} · ${usd(row.cost_usd)}`)); list.append(item);
+  });
+}
+function renderModels() {
+  const body = document.getElementById('models');
+  D.models.forEach(row => {
+    const tr = document.createElement('tr');
+    const name = document.createElement('td');
+    name.title = `sources: ${(row.sources || []).join(', ')}; hosts: ${(row.hosts || []).join(', ')}; accounts: ${(row.accounts || []).join(', ')}`;
+    name.append(node('div','model-name',row.model || 'unknown'));
+    name.append(node('div','meta',`${row.service || 'unknown'} ${row.provider ? '· '+row.provider : ''} · ${(row.hosts || []).length || 'all'} hosts`));
+    tr.append(name);
+    [['days',fmt(row.days)],['input',fmt(row.input_tokens)],['output',fmt(row.output_tokens)],['cache',fmt(Number(row.cache_creation_tokens || 0)+Number(row.cache_read_tokens || 0))],['total',fmt(row.total_tokens)],['cost',usd(row.cost_usd)]].forEach(([, value]) => tr.append(node('td','num',value)));
+    body.append(tr);
+  });
+}
+function renderHosts() {
+  const root = document.getElementById('hosts');
+  (D.hosts || []).forEach(row => { const status = row.status || 'missing'; const item = node('div','host '+status); item.title = row.message || row.cache || ''; item.append(node('span','dot', status === 'updated' ? '● ' : status === 'cached' ? '◐ ' : '○ ')); item.append(document.createTextNode(`${row.host || 'host'} · ${status}`)); root.append(item); });
+}
+renderStats(); renderChart(); renderCost(); renderServices(); renderModels(); renderHosts();
+</script>
+</body>
+</html>
+"""
+
+
+def write_html(path: Path, combined: dict[str, Any], daily: list[dict[str, Any]]) -> None:
+    payload = dashboard_payload(combined, daily)
+    rendered = HTML_TEMPLATE.replace("__DATA__", json_for_script(payload))
+    rendered = rendered.replace("AI Usage Ledger", html_escape("AI Usage Ledger"), 1)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(rendered, encoding="utf-8")
+    tmp.replace(path)
+
+
 def build_combined(host_payloads: list[tuple[HostSpec, dict[str, Any], bool]], statuses: list[dict[str, Any]]) -> dict[str, Any]:
     records: list[dict[str, Any]] = []
     for spec, payload, cached in host_payloads:
@@ -894,7 +1242,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-csv", type=Path, default=Path(DEFAULT_CSV), help=f"Combined CSV output, default {DEFAULT_CSV}.")
     parser.add_argument("--daily-json", type=Path, default=Path(DEFAULT_DAILY_JSON), help=f"Daily aggregate JSON output, default {DEFAULT_DAILY_JSON}.")
     parser.add_argument("--daily-csv", type=Path, default=Path(DEFAULT_DAILY_CSV), help=f"Daily aggregate CSV output, default {DEFAULT_DAILY_CSV}.")
+    parser.add_argument("--html", type=Path, default=Path(DEFAULT_HTML), help=f"Static HTML dashboard output, default {DEFAULT_HTML}.")
     parser.add_argument("--no-daily", action="store_true", help="Skip daily aggregate outputs.")
+    parser.add_argument("--no-html", action="store_true", help="Skip static HTML dashboard output.")
     parser.add_argument("--daily-split-hosts", action="store_true", help="Keep hosts separate in daily aggregates instead of merging them.")
     parser.add_argument("--daily-split-accounts", action="store_true", help="Keep accounts separate in daily aggregates instead of merging them.")
     parser.add_argument("--ssh-timeout", type=int, default=8, help="SSH connect timeout in seconds.")
@@ -944,15 +1294,18 @@ def main() -> int:
         host_payloads.append((spec, payload, cached))
 
     combined = build_combined(host_payloads, statuses)
-    atomic_write_json(args.output_json, combined)
-    if not args.json_only:
-        write_csv(args.output_csv, combined["records"])
-    if not args.no_daily:
+    daily: list[dict[str, Any]] = []
+    if not args.no_daily or not args.no_html:
         daily = aggregate_daily(
             combined["records"],
             split_hosts=args.daily_split_hosts,
             split_accounts=args.daily_split_accounts,
         )
+
+    atomic_write_json(args.output_json, combined)
+    if not args.json_only:
+        write_csv(args.output_csv, combined["records"])
+    if not args.no_daily:
         atomic_write_json(
             args.daily_json,
             {
@@ -964,6 +1317,9 @@ def main() -> int:
         )
         if not args.json_only:
             write_daily_csv(args.daily_csv, daily)
+    if not args.no_html:
+        write_html(args.html, combined, daily)
+
     eprint(f"Wrote {args.output_json}")
     if not args.json_only:
         eprint(f"Wrote {args.output_csv}")
@@ -971,6 +1327,8 @@ def main() -> int:
         eprint(f"Wrote {args.daily_json}")
         if not args.json_only:
             eprint(f"Wrote {args.daily_csv}")
+    if not args.no_html:
+        eprint(f"Wrote {args.html}")
     return 0
 
 

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -839,12 +839,16 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .chart-head h2 { margin: 0; }
 .scale-control { display: flex; align-items: center; gap: 8px; color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; text-transform: uppercase; letter-spacing: .12em; }
 .scale-control select { color: var(--ink); background: var(--paper); border: 1px solid var(--rule); padding: 6px 8px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-.chart-body { display: grid; grid-template-columns: 58px minmax(0, 1fr); gap: 10px; align-items: start; }
+.chart-body { display: grid; grid-template-columns: 58px minmax(0, 1fr) 58px; gap: 10px; align-items: start; }
 .chart-stack { min-width: 0; }
 .y-axis { position: relative; height: 230px; border-bottom: 1px solid transparent; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .y-tick { position: absolute; right: 0; transform: translateY(50%); white-space: nowrap; }
+.cost-y-axis .y-tick { left: 0; right: auto; color: var(--gold); }
 .chart { position: relative; display: flex; align-items: flex-end; gap: 3px; height: 230px; padding: 10px 0 0; border-bottom: 1px solid var(--rule); }
 .gridline { position: absolute; left: 0; right: 0; border-top: 1px solid rgba(237,228,209,.08); z-index: 0; }
+.cost-overlay { position: absolute; inset: 10px 0 0 0; width: 100%; height: calc(100% - 10px); z-index: 3; pointer-events: none; overflow: visible; }
+.cost-overlay path { fill: none; stroke: var(--gold); stroke-width: 3; vector-effect: non-scaling-stroke; }
+.cost-overlay circle { fill: var(--paper); stroke: var(--gold); stroke-width: 2; vector-effect: non-scaling-stroke; }
 .day { position: relative; z-index: 1; flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
 .day:hover { outline: 1px solid var(--gold); outline-offset: 2px; opacity: 1; }
 .seg.in { background: var(--in); } .seg.out { background: var(--out); } .seg.cw { background: var(--cw); } .seg.cr { background: var(--cr); } .seg.rz { background: var(--rz); }
@@ -854,7 +858,7 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .axis-tick:last-child { transform: translateX(-100%); }
 .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 10px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .swatch { display: inline-block; width: 10px; height: 10px; margin-right: 5px; vertical-align: -1px; }
-.costline { display: block; width: 100%; height: 74px; margin-top: 10px; overflow: hidden; }
+.swatch.line { height: 2px; width: 18px; vertical-align: 3px; }
 .heatmaps { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; margin-top: 30px; }
 .heatmap-wrap { border-top: 1px solid var(--rule); padding-top: 12px; min-width: 0; }
 .heatmap-head { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; margin-bottom: 10px; }
@@ -923,9 +927,10 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
       <div class="chart-body">
         <div id="yAxis" class="y-axis" aria-label="Daily token y axis"></div>
         <div class="chart-stack">
-          <div id="chart" class="chart" aria-label="Daily token bars"></div>
+          <div id="chart" class="chart" aria-label="Daily token bars and reported cost curve"></div>
           <div id="chartAxis" class="chart-axis" aria-label="Daily token date axis"></div>
         </div>
+        <div id="costYAxis" class="y-axis cost-y-axis" aria-label="Daily cost y axis"></div>
       </div>
       <div class="legend">
         <span><i class="swatch" style="background:var(--in)"></i>input</span>
@@ -933,11 +938,11 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         <span><i class="swatch" style="background:var(--cw)"></i>cache write</span>
         <span><i class="swatch" style="background:var(--cr)"></i>cache read</span>
         <span><i class="swatch" style="background:var(--rz)"></i>reasoning</span>
+        <span><i class="swatch line" style="background:var(--gold)"></i>reported cost</span>
       </div>
-      <svg id="costline" class="costline" viewBox="0 0 1000 74" preserveAspectRatio="none" aria-label="Daily cost line"></svg>
     </div>
     <aside class="panel">
-      <h2>Service Mix</h2>
+      <h2>Provider Mix</h2>
       <div id="servicebar" class="servicebar"></div>
       <div id="services" class="service-list"></div>
       <div class="tokenmax">
@@ -945,7 +950,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         <div id="tokenmax" class="tokenmax-grid"></div>
         <div id="tokenmaxLine" class="tokenmax-line"></div>
       </div>
-      <p class="note">The service field is inferred from provider/model names, so Grok used through pi is counted as Grok while retaining source=pi.</p>
+      <p class="note">Provider mix groups usage by the model provider family: OpenAI, Claude, Gemini, Grok, opencode, and other ccusage-reported providers.</p>
     </aside>
   </section>
   <section class="heatmaps" aria-label="Daily heatmaps">
@@ -992,6 +997,11 @@ function selectedRows() { return (D.rows || []).filter(r => {
   const hostOk = state.hosts.includes('all') || state.hosts.length === 0 || rowHosts(r).some(host => state.hosts.includes(host));
   return (!state.from || r.date >= state.from) && (!state.to || r.date <= state.to) && hostOk;
 }); }
+function providerGroup(row) {
+  if (row.source === 'opencode') return 'opencode';
+  if (row.service === 'codex') return 'openai';
+  return row.service || row.provider || row.source || 'unknown';
+}
 function derive(rows) {
   const daysMap = new Map(), modelsMap = new Map(), servicesMap = new Map();
   rows.forEach(row => {
@@ -1001,13 +1011,15 @@ function derive(rows) {
     const modelKey = [row.service, row.provider, row.model].join('\u0000');
     if (!modelsMap.has(modelKey)) modelsMap.set(modelKey, {service: row.service, provider: row.provider, model: row.model, days: new Set(), sources: new Set(), hosts: new Set(), accounts: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
     const model = modelsMap.get(modelKey); addTotals(model, row); model.days.add(row.date); model.sources.add(row.source); (row.hosts || '').split(',').filter(Boolean).forEach(v => model.hosts.add(v)); (row.accounts || '').split(',').filter(Boolean).forEach(v => model.accounts.add(v));
-    const serviceKey = [row.source, row.service].join('\u0000');
-    if (!servicesMap.has(serviceKey)) servicesMap.set(serviceKey, {source: row.source, service: row.service, records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
-    addTotals(servicesMap.get(serviceKey), row);
+    const provider = providerGroup(row);
+    if (!servicesMap.has(provider)) servicesMap.set(provider, {provider, sources: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
+    const serviceBucket = servicesMap.get(provider);
+    serviceBucket.sources.add(row.source);
+    addTotals(serviceBucket, row);
   });
   const days = [...daysMap.values()].sort((a,b) => a.date.localeCompare(b.date));
   const models = [...modelsMap.values()].map(m => ({...m, days: m.days.size, sources: [...m.sources].sort(), hosts: [...m.hosts].sort(), accounts: [...m.accounts].sort()})).sort((a,b) => b.total_tokens - a.total_tokens);
-  const services = [...servicesMap.values()].sort((a,b) => b.total_tokens - a.total_tokens);
+  const services = [...servicesMap.values()].map(s => ({...s, sources: [...s.sources].sort()})).sort((a,b) => b.total_tokens - a.total_tokens);
   const summary = {records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, active_models: models.length, first_date: days[0]?.date || '', latest_date: days.at(-1)?.date || ''};
   days.forEach(day => addTotals(summary, day));
   return {days, models, services, summary};
@@ -1044,19 +1056,21 @@ function yTicks(max) {
   }
   return [0, .25, .5, .75, 1].map(ratio => Math.round(max * ratio));
 }
-function renderYAxis(max) {
-  const axis = clear('yAxis');
+function renderYAxis(max, axisId, formatter, drawGrid) {
+  const axis = clear(axisId);
   const chart = document.getElementById('chart');
-  chart.querySelectorAll('.gridline').forEach(line => line.remove());
+  if (drawGrid) chart.querySelectorAll('.gridline').forEach(line => line.remove());
   yTicks(max).forEach(value => {
     const ratio = scaleRatio(value, max);
     const bottom = Math.max(0, Math.min(100, ratio * 100));
-    const tick = node('span', 'y-tick', fmt(value));
+    const tick = node('span', 'y-tick', formatter(value));
     tick.style.bottom = bottom + '%';
     axis.append(tick);
-    const line = node('i', 'gridline');
-    line.style.bottom = bottom + '%';
-    chart.append(line);
+    if (drawGrid) {
+      const line = node('i', 'gridline');
+      line.style.bottom = bottom + '%';
+      chart.append(line);
+    }
   });
 }
 function renderChartAxis(days) {
@@ -1073,13 +1087,39 @@ function renderChartAxis(days) {
     axis.append(tick);
   }
 }
+function renderCostOverlay(root, days, maxCost) {
+  renderYAxis(maxCost, 'costYAxis', usd, false);
+  if (!days.length || !maxCost) return;
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('class', 'cost-overlay');
+  svg.setAttribute('viewBox', '0 0 1000 100');
+  svg.setAttribute('preserveAspectRatio', 'none');
+  const points = days.map((d, i) => {
+    const x = days.length === 1 ? 0 : i * (1000 / (days.length - 1));
+    const y = 100 - (scaleRatio(Number(d.cost_usd || 0), maxCost) * 100);
+    return [x, y];
+  });
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', points.map(([x, y], index) => `${index ? 'L' : 'M'}${x.toFixed(1)},${y.toFixed(1)}`).join(' '));
+  svg.append(path);
+  points.forEach(([x, y], index) => {
+    if (days.length > 120 && index % Math.ceil(days.length / 60) !== 0) return;
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', x.toFixed(1));
+    circle.setAttribute('cy', y.toFixed(1));
+    circle.setAttribute('r', '2.3');
+    svg.append(circle);
+  });
+  root.append(svg);
+}
 function renderChart(days) {
   const root = clear('chart');
-  const max = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
-  renderYAxis(max);
+  const maxTokens = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
+  const maxCost = Math.max(0, ...days.map(d => Number(d.cost_usd || 0)));
+  renderYAxis(maxTokens, 'yAxis', fmt, true);
   days.forEach(d => {
     const total = Number(d.total_tokens || 0);
-    const scaledTotal = scaleRatio(total, max) * 100;
+    const scaledTotal = scaleRatio(total, maxTokens) * 100;
     const day = node('div','day');
     day.title = `${d.date} · ${fmt(total)} tokens · ${usd(d.cost_usd)} · ${state.tokenScale} scale`;
     fields.forEach((f, idx) => {
@@ -1091,15 +1131,8 @@ function renderChart(days) {
     });
     root.append(day);
   });
+  renderCostOverlay(root, days, maxCost);
   renderChartAxis(days);
-}
-function renderCost(days) {
-  const svg = clear('costline');
-  const max = Math.max(0, ...days.map(d => Number(d.cost_usd || 0)));
-  if (!days.length || !max) { const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x','0'); t.setAttribute('y','38'); t.setAttribute('fill','#9d927f'); t.textContent = 'No reported cost data'; svg.append(t); return; }
-  const points = days.map((d, i) => { const x = days.length === 1 ? 0 : i * (1000 / (days.length - 1)); const y = 62 - (Number(d.cost_usd || 0) / max * 54); return `${x.toFixed(1)},${y.toFixed(1)}`; }).join(' ');
-  const line = document.createElementNS('http://www.w3.org/2000/svg','polyline'); line.setAttribute('points', points); line.setAttribute('fill','none'); line.setAttribute('stroke','#d8a33d'); line.setAttribute('stroke-width','3'); line.setAttribute('vector-effect','non-scaling-stroke'); svg.append(line);
-  const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x','1000'); t.setAttribute('y','12'); t.setAttribute('text-anchor','end'); t.setAttribute('fill','#d8a33d'); t.textContent = 'max ' + usd(max); svg.append(t);
 }
 function renderServices(services) {
   const palette = ['#d8a33d','#8fb8b6','#577f86','#7d6c9f','#d66b55','#77b77a','#ede4d1'];
@@ -1108,8 +1141,8 @@ function renderServices(services) {
   const list = clear('services');
   services.forEach((row, idx) => {
     const color = palette[idx % palette.length];
-    const bit = node('div','servicebit'); bit.style.width = (Number(row.total_tokens || 0) / total * 100) + '%'; bit.style.background = color; bit.title = `${row.source}/${row.service} · ${fmt(row.total_tokens)}`; bar.append(bit);
-    const item = node('div','service-row'); const left = node('span','',`${row.source}/${row.service}`); left.style.color = color; item.append(left); item.append(node('span','',`${fmt(row.total_tokens)} · ${usd(row.cost_usd)}`)); list.append(item);
+    const bit = node('div','servicebit'); bit.style.width = (Number(row.total_tokens || 0) / total * 100) + '%'; bit.style.background = color; bit.title = `${row.provider} · ${fmt(row.total_tokens)} · via ${(row.sources || []).join(', ')}`; bar.append(bit);
+    const item = node('div','service-row'); const left = node('span','',row.provider || 'unknown'); left.style.color = color; item.append(left); item.append(node('span','',`${fmt(row.total_tokens)} · ${usd(row.cost_usd)}`)); list.append(item);
   });
 }
 function renderTokenmax(days, summary) {
@@ -1259,7 +1292,7 @@ function applyTokenScale() {
 }
 function renderAll() {
   const derived = derive(selectedRows());
-  renderStats(derived.summary); renderChart(derived.days); renderCost(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderHeatmaps(derived.days); renderModels(derived.models); renderHosts();
+  renderStats(derived.summary); renderChart(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderHeatmaps(derived.days); renderModels(derived.models); renderHosts();
   const readout = document.getElementById('rangeReadout');
   const hostText = state.hosts.includes('all') ? 'all hosts' : state.hosts.join(', ');
   readout.textContent = `${derived.days.length} days · ${derived.summary.first_date || 'n/a'} to ${derived.summary.latest_date || 'n/a'} · ${hostText}`;

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -245,14 +245,15 @@ def collect_claude_raw(home: Path) -> list[dict[str, Any]]:
     return records
 
 
-def run_ccusage(mode: str, home: Path) -> dict[str, Any] | None:
+def run_ccusage(mode: str, home: Path, extra_args: list[str] | None = None) -> dict[str, Any] | None:
     if mode == "raw":
         return None
+    extra_args = extra_args or []
     command: list[str] | None = None
     if mode in {"auto", "ccusage"} and shutil.which("ccusage"):
-        command = ["ccusage", "daily", "--json"]
+        command = ["ccusage", "daily", "--json", *extra_args]
     elif mode in {"auto", "npx"} and shutil.which("npx"):
-        command = ["npx", "--yes", "ccusage@latest", "daily", "--json"]
+        command = ["npx", "--yes", "ccusage@latest", "daily", "--json", *extra_args]
     if command is None:
         return None
 
@@ -263,7 +264,7 @@ def run_ccusage(mode: str, home: Path) -> dict[str, Any] | None:
             command,
             text=True,
             capture_output=True,
-            timeout=90,
+            timeout=120,
             check=False,
             env=env,
         )
@@ -283,6 +284,10 @@ def run_ccusage(mode: str, home: Path) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def ccusage_day(day: dict[str, Any]) -> str:
+    return str(day.get("date") or day.get("period") or "")
+
+
 def collect_claude_ccusage(home: Path, mode: str) -> list[dict[str, Any]]:
     payload = run_ccusage(mode, home)
     if payload is None:
@@ -295,7 +300,7 @@ def collect_claude_ccusage(home: Path, mode: str) -> list[dict[str, Any]]:
     for day in daily:
         if not isinstance(day, dict):
             continue
-        date = str(day.get("date") or "")
+        date = ccusage_day(day)
         if not date:
             continue
         timestamp = f"{date}T00:00:00Z"
@@ -344,6 +349,82 @@ def collect_claude(home: Path, cost_source: str = "auto") -> list[dict[str, Any]
         if records:
             return records
     return collect_claude_raw(home)
+
+
+def normalize_ccusage_agent(agent: str) -> str:
+    aliases = {
+        "claude": "claude_code",
+        "opencode": "opencode",
+        "codex": "codex",
+        "pi": "pi",
+    }
+    return aliases.get(agent, agent or "ccusage")
+
+
+def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, Any]]:
+    payload = run_ccusage(mode, home, ["--by-agent"])
+    if payload is None:
+        return []
+    daily = payload.get("daily")
+    if not isinstance(daily, list):
+        return []
+
+    records: list[dict[str, Any]] = []
+    for day in daily:
+        if not isinstance(day, dict):
+            continue
+        date = ccusage_day(day)
+        if not date:
+            continue
+        timestamp = f"{date}T00:00:00Z"
+        agents = day.get("agents")
+        if not isinstance(agents, list):
+            agents = [day]
+        for agent_row in agents:
+            if not isinstance(agent_row, dict):
+                continue
+            agent = str(agent_row.get("agent") or day.get("agent") or "ccusage")
+            source = normalize_ccusage_agent(agent)
+            breakdowns = agent_row.get("modelBreakdowns")
+            if isinstance(breakdowns, list) and breakdowns:
+                for breakdown in breakdowns:
+                    if not isinstance(breakdown, dict):
+                        continue
+                    model = str(breakdown.get("modelName") or "")
+                    records.append(
+                        new_record(
+                            source=source,
+                            timestamp=timestamp,
+                            session_id=f"ccusage:{agent}:{date}:{model}",
+                            provider=agent,
+                            model=model,
+                            input_tokens=as_int(breakdown.get("inputTokens")),
+                            output_tokens=as_int(breakdown.get("outputTokens")),
+                            cache_creation_tokens=as_int(breakdown.get("cacheCreationTokens")),
+                            cache_read_tokens=as_int(breakdown.get("cacheReadTokens")),
+                            total_tokens=as_int(breakdown.get("totalTokens")),
+                            cost_usd=as_float(breakdown.get("cost")),
+                            source_path="ccusage daily --json --by-agent",
+                        )
+                    )
+            else:
+                records.append(
+                    new_record(
+                        source=source,
+                        timestamp=timestamp,
+                        session_id=f"ccusage:{agent}:{date}",
+                        provider=agent,
+                        model=", ".join(str(model) for model in agent_row.get("modelsUsed", []) if model),
+                        input_tokens=as_int(agent_row.get("inputTokens")),
+                        output_tokens=as_int(agent_row.get("outputTokens")),
+                        cache_creation_tokens=as_int(agent_row.get("cacheCreationTokens")),
+                        cache_read_tokens=as_int(agent_row.get("cacheReadTokens")),
+                        total_tokens=as_int(agent_row.get("totalTokens")),
+                        cost_usd=as_float(agent_row.get("totalCost")),
+                        source_path="ccusage daily --json --by-agent",
+                    )
+                )
+    return records
 
 
 def collect_pi(home: Path) -> list[dict[str, Any]]:
@@ -520,10 +601,33 @@ def collect_opencode(home: Path) -> list[dict[str, Any]]:
     return records
 
 
-def collect_local(host_label: str = "", claude_cost_source: str = "auto") -> dict[str, Any]:
+def collect_local(
+    host_label: str = "", claude_cost_source: str = "auto", usage_source: str = "ccusage"
+) -> dict[str, Any]:
     home = Path.home()
     label = host_label or socket.gethostname().split(".", 1)[0]
     records = []
+
+    if usage_source in {"ccusage", "auto"}:
+        try:
+            records = collect_ccusage_unified(home, claude_cost_source)
+        except Exception as exc:  # noqa: BLE001 - ccusage failure should fall through to local parsers.
+            eprint(f"Warning: collect_ccusage_unified failed: {exc}")
+        if records or usage_source == "ccusage":
+            records.sort(key=lambda item: (item.get("timestamp") or "", item.get("source") or "", item.get("session_id") or ""))
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "host": label,
+                "collected_at": utc_now(),
+                "platform": {
+                    "hostname": socket.gethostname(),
+                    "system": platform.system(),
+                    "release": platform.release(),
+                },
+                "records": records,
+                "summary": summarize_records(records),
+            }
+
     collectors = (
         ("collect_claude", lambda: collect_claude(home, claude_cost_source)),
         ("collect_pi", lambda: collect_pi(home)),
@@ -634,7 +738,9 @@ def parse_host_arg(value: str) -> HostSpec:
     return HostSpec(label=value, target=value)
 
 
-def run_remote_collect(spec: HostSpec, timeout: int, claude_cost_source: str) -> tuple[dict[str, Any] | None, str]:
+def run_remote_collect(
+    spec: HostSpec, timeout: int, claude_cost_source: str, usage_source: str
+) -> tuple[dict[str, Any] | None, str]:
     script = Path(__file__).read_text(encoding="utf-8")
     command = [
         "ssh",
@@ -650,6 +756,8 @@ def run_remote_collect(spec: HostSpec, timeout: int, claude_cost_source: str) ->
         spec.label,
         "--claude-cost-source",
         claude_cost_source,
+        "--usage-source",
+        usage_source,
     ]
     try:
         completed = subprocess.run(
@@ -673,7 +781,7 @@ def run_remote_collect(spec: HostSpec, timeout: int, claude_cost_source: str) ->
 
 
 def collect_host(
-    spec: HostSpec, cache_dir: Path, timeout: int, claude_cost_source: str
+    spec: HostSpec, cache_dir: Path, timeout: int, claude_cost_source: str, usage_source: str
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     path = cache_path(cache_dir, spec.label)
     status = {
@@ -685,12 +793,12 @@ def collect_host(
     }
 
     if spec.is_local:
-        payload = collect_local(spec.label, claude_cost_source)
+        payload = collect_local(spec.label, claude_cost_source, usage_source)
         status["status"] = "updated"
         atomic_write_json(path, payload)
         return payload, status
 
-    payload, error = run_remote_collect(spec, timeout, claude_cost_source)
+    payload, error = run_remote_collect(spec, timeout, claude_cost_source, usage_source)
     if payload is not None:
         status["status"] = "updated"
         atomic_write_json(path, payload)
@@ -1009,12 +1117,36 @@ def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> 
         "accounts": len(accounts_seen),
     }
 
+    rows = []
+    for record in sorted(daily, key=lambda item: (item.get("date") or "", item.get("source") or "", item.get("model") or "")):
+        rows.append(
+            {
+                "date": str(record.get("date") or ""),
+                "source": str(record.get("source") or ""),
+                "service": str(record.get("service") or ""),
+                "provider": str(record.get("provider") or ""),
+                "model": str(record.get("model") or ""),
+                "hosts": str(record.get("hosts") or ""),
+                "accounts": str(record.get("accounts") or ""),
+                "records": as_int(record.get("records")),
+                "sessions": as_int(record.get("sessions")),
+                "input_tokens": as_int(record.get("input_tokens")),
+                "output_tokens": as_int(record.get("output_tokens")),
+                "cache_creation_tokens": as_int(record.get("cache_creation_tokens")),
+                "cache_read_tokens": as_int(record.get("cache_read_tokens")),
+                "reasoning_tokens": as_int(record.get("reasoning_tokens")),
+                "total_tokens": as_int(record.get("total_tokens")),
+                "cost_usd": round(as_float(record.get("cost_usd")), 6),
+            }
+        )
+
     return {
         "generated_at": combined.get("generated_at") or utc_now(),
         "summary": totals,
         "days": days,
         "models": models[:30],
         "services": services,
+        "rows": rows,
         "hosts": combined.get("statuses", []),
     }
 
@@ -1061,6 +1193,13 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .stat { padding: 18px 14px 16px; border-right: 1px solid var(--rule); min-width: 0; }
 .stat:last-child { border-right: 0; }
 .value { font: 29px/.95 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: -.05em; white-space: nowrap; }
+.rangebar { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 16px 0; border-bottom: 1px solid var(--rule); }
+.presets { display: flex; flex-wrap: wrap; gap: 8px; }
+.rangebar button, .rangebar input { color: var(--ink); background: transparent; border: 1px solid var(--rule); padding: 8px 10px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.rangebar button { cursor: pointer; text-transform: uppercase; letter-spacing: .08em; }
+.rangebar button.active, .rangebar button:hover, .rangebar input:focus { border-color: var(--gold); outline: 0; }
+.custom-range { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.range-readout { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin-left: 6px; }
 .grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 28px; margin-top: 30px; }
 .panel { border-top: 1px solid var(--rule-strong); padding-top: 14px; min-width: 0; }
 .panel h2 { margin: 0 0 14px; font-size: 22px; font-weight: 500; letter-spacing: -.02em; }
@@ -1075,6 +1214,11 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .servicebit { min-width: 2px; }
 .service-list { display: grid; gap: 8px; }
 .service-row { display: grid; grid-template-columns: 1fr auto; gap: 12px; font: 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
+.tokenmax { margin-top: 20px; border-top: 1px solid var(--rule); padding-top: 14px; }
+.tokenmax-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.tokenmax-metric { border-left: 1px solid var(--rule); padding-left: 10px; }
+.tokenmax-metric strong { display: block; font: 22px/.95 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: -.04em; }
+.tokenmax-line { margin-top: 12px; color: var(--gold); font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 table { width: 100%; border-collapse: collapse; font: 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 th, td { padding: 10px 8px; border-bottom: 1px solid var(--rule); vertical-align: top; }
 th { text-align: left; }
@@ -1085,7 +1229,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .host { border: 1px solid var(--rule); padding: 7px 9px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
 .host.updated .dot { color: var(--green); } .host.cached .dot { color: var(--gold); } .host.missing .dot { color: var(--red); }
 .note { color: var(--muted); font-size: 13px; line-height: 1.45; margin-top: 12px; }
-@media (max-width: 900px) { .mast, .grid { display: block; } .generated { text-align: left; margin-top: 14px; } .stats { grid-template-columns: repeat(2, 1fr); } .stat:nth-child(2n) { border-right: 0; } }
+@media (max-width: 900px) { .mast, .grid, .rangebar { display: block; } .custom-range { margin-top: 12px; } .generated { text-align: left; margin-top: 14px; } .stats { grid-template-columns: repeat(2, 1fr); } .stat:nth-child(2n) { border-right: 0; } }
 </style>
 </head>
 <body>
@@ -1095,6 +1239,20 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
     <div class="generated"><div class="label">Generated</div><div id="generated"></div><p class="note">Accounts are merged by default. Cost is reported only when the source provides it.</p></div>
   </header>
   <section class="stats" id="stats" aria-label="Summary statistics"></section>
+  <section class="rangebar" aria-label="Date range selector">
+    <div class="presets" id="presets">
+      <button type="button" data-range="all" class="active">All</button>
+      <button type="button" data-range="7">7D</button>
+      <button type="button" data-range="30">30D</button>
+      <button type="button" data-range="90">90D</button>
+      <button type="button" data-range="365">1Y</button>
+    </div>
+    <div class="custom-range">
+      <span class="label">From</span><input id="fromDate" type="date">
+      <span class="label">To</span><input id="toDate" type="date">
+      <span class="range-readout" id="rangeReadout"></span>
+    </div>
+  </section>
   <section class="grid">
     <div class="panel">
       <h2>Daily Token Flow</h2>
@@ -1112,6 +1270,11 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
       <h2>Service Mix</h2>
       <div id="servicebar" class="servicebar"></div>
       <div id="services" class="service-list"></div>
+      <div class="tokenmax">
+        <h2>Tokenmaxxing</h2>
+        <div id="tokenmax" class="tokenmax-grid"></div>
+        <div id="tokenmaxLine" class="tokenmax-line"></div>
+      </div>
       <p class="note">The service field is inferred from provider/model names, so Grok used through pi is counted as Grok while retaining source=pi.</p>
     </aside>
   </section>
@@ -1132,53 +1295,90 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 const D = JSON.parse(document.getElementById('usage-data').textContent);
 const fields = ['input_tokens','output_tokens','cache_creation_tokens','cache_read_tokens','reasoning_tokens'];
 const segClass = ['in','out','cw','cr','rz'];
+let state = { from: null, to: null, preset: 'all' };
 function fmt(n) { n = Number(n || 0); if (n >= 1e9) return (n/1e9).toFixed(1)+'B'; if (n >= 1e6) return (n/1e6).toFixed(1)+'M'; if (n >= 1e3) return (n/1e3).toFixed(0)+'k'; return String(Math.round(n)); }
 function usd(n) { return '$' + Number(n || 0).toFixed(2); }
+function pct(n) { return Number(n || 0).toFixed(1) + '%'; }
 function node(tag, cls, text) { const el = document.createElement(tag); if (cls) el.className = cls; if (text !== undefined) el.textContent = text; return el; }
-function renderStats() {
+function clear(id) { const el = document.getElementById(id); while (el.firstChild) el.removeChild(el.firstChild); return el; }
+function addTotals(target, row) { fields.concat(['total_tokens']).forEach(f => target[f] = Number(target[f] || 0) + Number(row[f] || 0)); target.cost_usd = Number(target.cost_usd || 0) + Number(row.cost_usd || 0); target.records = Number(target.records || 0) + Number(row.records || 0); target.sessions = Number(target.sessions || 0) + Number(row.sessions || 0); }
+function dateAdd(date, delta) { const d = new Date(date + 'T00:00:00Z'); d.setUTCDate(d.getUTCDate() + delta); return d.toISOString().slice(0,10); }
+function availableDates() { return [...new Set((D.rows || []).map(r => r.date).filter(Boolean))].sort(); }
+function selectedRows() { return (D.rows || []).filter(r => (!state.from || r.date >= state.from) && (!state.to || r.date <= state.to)); }
+function derive(rows) {
+  const daysMap = new Map(), modelsMap = new Map(), servicesMap = new Map();
+  rows.forEach(row => {
+    if (!row.date) return;
+    if (!daysMap.has(row.date)) daysMap.set(row.date, {date: row.date, records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
+    addTotals(daysMap.get(row.date), row);
+    const modelKey = [row.service, row.provider, row.model].join('\u0000');
+    if (!modelsMap.has(modelKey)) modelsMap.set(modelKey, {service: row.service, provider: row.provider, model: row.model, days: new Set(), sources: new Set(), hosts: new Set(), accounts: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
+    const model = modelsMap.get(modelKey); addTotals(model, row); model.days.add(row.date); model.sources.add(row.source); (row.hosts || '').split(',').filter(Boolean).forEach(v => model.hosts.add(v)); (row.accounts || '').split(',').filter(Boolean).forEach(v => model.accounts.add(v));
+    const serviceKey = [row.source, row.service].join('\u0000');
+    if (!servicesMap.has(serviceKey)) servicesMap.set(serviceKey, {source: row.source, service: row.service, records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
+    addTotals(servicesMap.get(serviceKey), row);
+  });
+  const days = [...daysMap.values()].sort((a,b) => a.date.localeCompare(b.date));
+  const models = [...modelsMap.values()].map(m => ({...m, days: m.days.size, sources: [...m.sources].sort(), hosts: [...m.hosts].sort(), accounts: [...m.accounts].sort()})).sort((a,b) => b.total_tokens - a.total_tokens);
+  const services = [...servicesMap.values()].sort((a,b) => b.total_tokens - a.total_tokens);
+  const summary = {records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, active_models: models.length, first_date: days[0]?.date || '', latest_date: days.at(-1)?.date || ''};
+  days.forEach(day => addTotals(summary, day));
+  return {days, models, services, summary};
+}
+function renderStats(summary) {
   document.getElementById('generated').textContent = D.generated_at || 'unknown';
   const stats = [
-    ['total', fmt(D.summary.total_tokens)], ['input', fmt(D.summary.input_tokens)], ['output', fmt(D.summary.output_tokens)],
-    ['cache read', fmt(D.summary.cache_read_tokens)], ['cache write', fmt(D.summary.cache_creation_tokens)], ['cost', usd(D.summary.cost_usd)],
-    ['models', fmt(D.summary.active_models)], ['latest', D.summary.latest_date || 'n/a']
+    ['total', fmt(summary.total_tokens)], ['input', fmt(summary.input_tokens)], ['output', fmt(summary.output_tokens)],
+    ['cache read', fmt(summary.cache_read_tokens)], ['cache write', fmt(summary.cache_creation_tokens)], ['cost', usd(summary.cost_usd)],
+    ['models', fmt(summary.active_models)], ['latest', summary.latest_date || 'n/a']
   ];
-  const root = document.getElementById('stats');
+  const root = clear('stats');
   stats.forEach(([label, value]) => { const box = node('div','stat'); box.append(node('div','label',label)); box.append(node('div','value',value)); root.append(box); });
 }
-function renderChart() {
-  const root = document.getElementById('chart');
-  const days = D.days || [];
+function renderChart(days) {
+  const root = clear('chart');
   const max = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
   days.forEach(d => {
     const day = node('div','day');
     day.title = `${d.date} · ${fmt(d.total_tokens)} tokens · ${usd(d.cost_usd)}`;
-    fields.forEach((f, idx) => { const seg = node('div', 'seg ' + segClass[idx]); const pct = Math.max(0, Number(d[f] || 0) / max * 100); seg.style.height = pct ? Math.max(.8, pct) + '%' : '0'; day.append(seg); });
+    fields.forEach((f, idx) => { const seg = node('div', 'seg ' + segClass[idx]); const height = Math.max(0, Number(d[f] || 0) / max * 100); seg.style.height = height ? Math.max(.8, height) + '%' : '0'; day.append(seg); });
     root.append(day);
   });
 }
-function renderCost() {
-  const svg = document.getElementById('costline');
-  const days = D.days || [];
+function renderCost(days) {
+  const svg = clear('costline');
   const max = Math.max(0, ...days.map(d => Number(d.cost_usd || 0)));
   if (!days.length || !max) { const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x','0'); t.setAttribute('y','38'); t.setAttribute('fill','#9d927f'); t.textContent = 'No reported cost data'; svg.append(t); return; }
   const points = days.map((d, i) => { const x = days.length === 1 ? 0 : i * (1000 / (days.length - 1)); const y = 62 - (Number(d.cost_usd || 0) / max * 54); return `${x.toFixed(1)},${y.toFixed(1)}`; }).join(' ');
   const line = document.createElementNS('http://www.w3.org/2000/svg','polyline'); line.setAttribute('points', points); line.setAttribute('fill','none'); line.setAttribute('stroke','#d8a33d'); line.setAttribute('stroke-width','3'); line.setAttribute('vector-effect','non-scaling-stroke'); svg.append(line);
   const t = document.createElementNS('http://www.w3.org/2000/svg','text'); t.setAttribute('x','1000'); t.setAttribute('y','12'); t.setAttribute('text-anchor','end'); t.setAttribute('fill','#d8a33d'); t.textContent = 'max ' + usd(max); svg.append(t);
 }
-function renderServices() {
+function renderServices(services) {
   const palette = ['#d8a33d','#8fb8b6','#577f86','#7d6c9f','#d66b55','#77b77a','#ede4d1'];
-  const total = Math.max(1, D.services.reduce((sum, row) => sum + Number(row.total_tokens || 0), 0));
-  const bar = document.getElementById('servicebar');
-  const list = document.getElementById('services');
-  D.services.forEach((row, idx) => {
+  const total = Math.max(1, services.reduce((sum, row) => sum + Number(row.total_tokens || 0), 0));
+  const bar = clear('servicebar');
+  const list = clear('services');
+  services.forEach((row, idx) => {
     const color = palette[idx % palette.length];
     const bit = node('div','servicebit'); bit.style.width = (Number(row.total_tokens || 0) / total * 100) + '%'; bit.style.background = color; bit.title = `${row.source}/${row.service} · ${fmt(row.total_tokens)}`; bar.append(bit);
     const item = node('div','service-row'); const left = node('span','',`${row.source}/${row.service}`); left.style.color = color; item.append(left); item.append(node('span','',`${fmt(row.total_tokens)} · ${usd(row.cost_usd)}`)); list.append(item);
   });
 }
-function renderModels() {
-  const body = document.getElementById('models');
-  D.models.forEach(row => {
+function renderTokenmax(days, summary) {
+  const root = clear('tokenmax');
+  const peak = days.reduce((best, day) => Number(day.total_tokens || 0) > Number(best.total_tokens || 0) ? day : best, {date:'n/a', total_tokens:0});
+  const avg = days.length ? summary.total_tokens / days.length : 0;
+  const cache = Number(summary.cache_creation_tokens || 0) + Number(summary.cache_read_tokens || 0);
+  const direct = Number(summary.input_tokens || 0) + Number(summary.output_tokens || 0);
+  const cacheMult = direct ? cache / direct : 0;
+  const outputShare = summary.total_tokens ? summary.output_tokens / summary.total_tokens * 100 : 0;
+  [['peak day', `${fmt(peak.total_tokens)} on ${peak.date}`], ['avg/day', fmt(avg)], ['cache multiplier', cacheMult.toFixed(1)+'×'], ['output share', pct(outputShare)]].forEach(([label, value]) => { const box = node('div','tokenmax-metric'); box.append(node('div','label',label)); box.append(node('strong','',value)); root.append(box); });
+  const line = document.getElementById('tokenmaxLine');
+  line.textContent = summary.total_tokens ? `You are tokenmaxxing at ${fmt(avg)} tokens/day in this range, with ${fmt(cache)} cache tokens doing the heavy lifting.` : 'No tokens in this range.';
+}
+function renderModels(models) {
+  const body = clear('models');
+  models.slice(0, 30).forEach(row => {
     const tr = document.createElement('tr');
     const name = document.createElement('td');
     name.title = `sources: ${(row.sources || []).join(', ')}; hosts: ${(row.hosts || []).join(', ')}; accounts: ${(row.accounts || []).join(', ')}`;
@@ -1190,10 +1390,38 @@ function renderModels() {
   });
 }
 function renderHosts() {
-  const root = document.getElementById('hosts');
+  const root = clear('hosts');
   (D.hosts || []).forEach(row => { const status = row.status || 'missing'; const item = node('div','host '+status); item.title = row.message || row.cache || ''; item.append(node('span','dot', status === 'updated' ? '● ' : status === 'cached' ? '◐ ' : '○ ')); item.append(document.createTextNode(`${row.host || 'host'} · ${status}`)); root.append(item); });
 }
-renderStats(); renderChart(); renderCost(); renderServices(); renderModels(); renderHosts();
+function applyRange(preset) {
+  const dates = availableDates();
+  if (!dates.length) return renderAll();
+  const latest = dates.at(-1);
+  state.preset = preset;
+  if (preset === 'all') { state.from = dates[0]; state.to = latest; }
+  else { state.to = latest; state.from = dateAdd(latest, -Number(preset) + 1); }
+  document.getElementById('fromDate').value = state.from;
+  document.getElementById('toDate').value = state.to;
+  document.querySelectorAll('#presets button').forEach(b => b.classList.toggle('active', b.dataset.range === preset));
+  renderAll();
+}
+function applyCustomRange() {
+  state.from = document.getElementById('fromDate').value || null;
+  state.to = document.getElementById('toDate').value || null;
+  state.preset = 'custom';
+  document.querySelectorAll('#presets button').forEach(b => b.classList.remove('active'));
+  renderAll();
+}
+function renderAll() {
+  const derived = derive(selectedRows());
+  renderStats(derived.summary); renderChart(derived.days); renderCost(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderModels(derived.models); renderHosts();
+  const readout = document.getElementById('rangeReadout');
+  readout.textContent = `${derived.days.length} days · ${derived.summary.first_date || 'n/a'} to ${derived.summary.latest_date || 'n/a'}`;
+}
+document.querySelectorAll('#presets button').forEach(button => button.addEventListener('click', () => applyRange(button.dataset.range)));
+document.getElementById('fromDate').addEventListener('change', applyCustomRange);
+document.getElementById('toDate').addEventListener('change', applyCustomRange);
+applyRange('all');
 </script>
 </body>
 </html>
@@ -1252,7 +1480,13 @@ def parse_args() -> argparse.Namespace:
         "--claude-cost-source",
         choices=("auto", "raw", "ccusage", "npx"),
         default="auto",
-        help="Claude Code source: auto uses installed ccusage or npx ccusage@latest, raw parses JSONL only.",
+        help="ccusage runner: auto uses installed ccusage or npx ccusage@latest, raw uses local parsers only.",
+    )
+    parser.add_argument(
+        "--usage-source",
+        choices=("ccusage", "auto", "local"),
+        default="ccusage",
+        help="Primary usage collector. ccusage uses unified ccusage data; auto falls back to local parsers; local skips ccusage.",
     )
     parser.add_argument("--json-only", action="store_true", help="Do not write CSV output.")
     parser.add_argument("--collect-local", action="store_true", help=argparse.SUPPRESS)
@@ -1263,7 +1497,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     if args.collect_local:
-        print(json.dumps(collect_local(args.host_label, args.claude_cost_source), sort_keys=True))
+        print(json.dumps(collect_local(args.host_label, args.claude_cost_source, args.usage_source), sort_keys=True))
         return 0
 
     specs = default_specs(not args.no_local)
@@ -1283,7 +1517,7 @@ def main() -> int:
     host_payloads: list[tuple[HostSpec, dict[str, Any], bool]] = []
     statuses: list[dict[str, Any]] = []
     for spec in specs:
-        payload, status = collect_host(spec, args.cache_dir, args.ssh_timeout, args.claude_cost_source)
+        payload, status = collect_host(spec, args.cache_dir, args.ssh_timeout, args.claude_cost_source, args.usage_source)
         statuses.append(status)
         if payload is None:
             eprint(f"{spec.label}: no data ({status.get('message')})")

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -8,6 +8,7 @@ responses, tool arguments, auth files, or raw transcripts into the output.
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import csv
 import datetime as dt
 import html
@@ -20,11 +21,13 @@ import shutil
 import socket
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_CACHE_DIR = ".ai-usage-cache"
 DEFAULT_INVENTORY = "ai-usage.hosts"
 DEFAULT_JSON = "ai-usage.json"
@@ -32,6 +35,9 @@ DEFAULT_CSV = "ai-usage.csv"
 DEFAULT_DAILY_JSON = "ai-usage-daily.json"
 DEFAULT_DAILY_CSV = "ai-usage-daily.csv"
 DEFAULT_HTML = "ai-usage.html"
+DEFAULT_CCUSAGE_PACKAGE = "ccusage@latest"
+D3_VERSION = "7.9.0"
+D3_URL = f"https://cdn.jsdelivr.net/npm/d3@{D3_VERSION}/dist/d3.min.js"
 
 
 @dataclass
@@ -93,7 +99,7 @@ def infer_service(source: str, provider: str, model: str) -> str:
         return "codex"
     if "gemini" in haystack:
         return "gemini"
-    if "openai" in haystack or normalized_model.startswith("gpt-") or normalized_model.startswith("o"):
+    if "openai" in haystack or normalized_model.startswith("gpt-") or re.match(r"o\d", normalized_model):
         return "openai"
     if "kimi" in haystack:
         return "kimi"
@@ -144,11 +150,13 @@ def new_record(
     }
 
 
-def run_ccusage(mode: str, home: Path, extra_args: list[str] | None = None) -> dict[str, Any] | None:
+def run_ccusage(
+    mode: str, home: Path, extra_args: list[str] | None = None, package: str = DEFAULT_CCUSAGE_PACKAGE
+) -> dict[str, Any] | None:
     extra_args = extra_args or []
     command: list[str] | None = None
     if mode in {"auto", "npx"} and shutil.which("npx"):
-        command = ["npx", "--yes", "ccusage@latest", "daily", "--json", *extra_args]
+        command = ["npx", "--yes", package, "daily", "--json", *extra_args]
     elif mode in {"auto", "ccusage"} and shutil.which("ccusage"):
         command = ["ccusage", "daily", "--json", *extra_args]
     if command is None:
@@ -195,8 +203,13 @@ def normalize_ccusage_agent(agent: str) -> str:
     return aliases.get(agent, agent or "ccusage")
 
 
-def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, Any]]:
-    payload = run_ccusage(mode, home, ["--by-agent"])
+def collect_ccusage_unified(
+    home: Path, mode: str = "auto", timezone: str = "", package: str = DEFAULT_CCUSAGE_PACKAGE
+) -> list[dict[str, Any]]:
+    extra_args = ["--by-agent"]
+    if timezone:
+        extra_args.extend(["--timezone", timezone])
+    payload = run_ccusage(mode, home, extra_args, package)
     if payload is None:
         return []
     daily = payload.get("daily")
@@ -236,6 +249,7 @@ def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, An
                             output_tokens=as_int(breakdown.get("outputTokens")),
                             cache_creation_tokens=as_int(breakdown.get("cacheCreationTokens")),
                             cache_read_tokens=as_int(breakdown.get("cacheReadTokens")),
+                            reasoning_tokens=as_int(breakdown.get("reasoningTokens")),
                             total_tokens=as_int(breakdown.get("totalTokens")),
                             cost_usd=as_float(breakdown.get("cost")),
                             source_path="ccusage daily --json --by-agent",
@@ -253,6 +267,7 @@ def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, An
                         output_tokens=as_int(agent_row.get("outputTokens")),
                         cache_creation_tokens=as_int(agent_row.get("cacheCreationTokens")),
                         cache_read_tokens=as_int(agent_row.get("cacheReadTokens")),
+                        reasoning_tokens=as_int(agent_row.get("reasoningTokens")),
                         total_tokens=as_int(agent_row.get("totalTokens")),
                         cost_usd=as_float(agent_row.get("totalCost")),
                         source_path="ccusage daily --json --by-agent",
@@ -261,12 +276,43 @@ def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, An
     return records
 
 
-def collect_local(host_label: str = "", ccusage_runner: str = "auto") -> dict[str, Any]:
+def machine_id() -> str:
+    """Best-effort stable hardware identifier, used to catch the same machine listed under two labels."""
+    for candidate in ("/etc/machine-id", "/var/lib/dbus/machine-id"):
+        try:
+            value = Path(candidate).read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if value:
+            return value
+    if platform.system() == "Darwin":
+        try:
+            completed = subprocess.run(
+                ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+                text=True,
+                capture_output=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ""
+        match = re.search(r'"IOPlatformUUID"\s*=\s*"([^"]+)"', completed.stdout)
+        if match:
+            return match.group(1)
+    return ""
+
+
+def collect_local(
+    host_label: str = "",
+    ccusage_runner: str = "auto",
+    timezone: str = "",
+    ccusage_package: str = DEFAULT_CCUSAGE_PACKAGE,
+) -> dict[str, Any]:
     home = Path.home()
     label = host_label or socket.gethostname().split(".", 1)[0]
     records: list[dict[str, Any]] = []
     try:
-        records = collect_ccusage_unified(home, ccusage_runner)
+        records = collect_ccusage_unified(home, ccusage_runner, timezone, ccusage_package)
     except Exception as exc:  # noqa: BLE001 - one host should not block cached/offline behavior elsewhere.
         eprint(f"Warning: collect_ccusage_unified failed: {exc}")
 
@@ -274,6 +320,7 @@ def collect_local(host_label: str = "", ccusage_runner: str = "auto") -> dict[st
     return {
         "schema_version": SCHEMA_VERSION,
         "host": label,
+        "machine_id": machine_id(),
         "collected_at": utc_now(),
         "platform": {
             "hostname": socket.gethostname(),
@@ -326,6 +373,47 @@ def load_json(path: Path) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
+def record_key(record: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(record.get("date") or ""),
+        str(record.get("source") or ""),
+        str(record.get("provider") or ""),
+        str(record.get("model") or ""),
+    )
+
+
+def merge_payload(cached: dict[str, Any] | None, fresh: dict[str, Any]) -> dict[str, Any]:
+    """Merge a fresh collection into the cached ledger.
+
+    The cache is an append-only ledger: records that disappear from a host's local
+    logs (pruned transcripts, reinstalls, a broken ccusage) are retained from the
+    cache. When both sides have a record for the same (date, source, provider,
+    model), the one with more total tokens wins — daily counts only ever grow.
+    """
+    fresh_records = [r for r in fresh.get("records", []) if isinstance(r, dict)]
+    if cached is None:
+        return fresh
+    ledger: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for record in cached.get("records", []):
+        if isinstance(record, dict):
+            ledger[record_key(record)] = record
+    for record in fresh_records:
+        key = record_key(record)
+        previous = ledger.get(key)
+        if previous is None or as_int(record.get("total_tokens")) >= as_int(previous.get("total_tokens")):
+            ledger[key] = record
+    records = sorted(
+        ledger.values(),
+        key=lambda item: (item.get("timestamp") or "", item.get("source") or "", item.get("session_id") or ""),
+    )
+    merged = dict(fresh)
+    merged["records"] = records
+    merged["summary"] = summarize_records(records)
+    if not merged.get("machine_id"):
+        merged["machine_id"] = str(cached.get("machine_id") or "")
+    return merged
+
+
 def parse_inventory(path: Path) -> list[HostSpec]:
     specs: list[HostSpec] = []
     try:
@@ -369,7 +457,11 @@ def parse_host_arg(value: str) -> HostSpec:
 
 
 def run_remote_collect(
-    spec: HostSpec, timeout: int, ccusage_runner: str
+    spec: HostSpec,
+    timeout: int,
+    ccusage_runner: str,
+    timezone: str = "",
+    ccusage_package: str = DEFAULT_CCUSAGE_PACKAGE,
 ) -> tuple[dict[str, Any] | None, str]:
     script = Path(__file__).read_text(encoding="utf-8")
     command = [
@@ -386,7 +478,11 @@ def run_remote_collect(
         spec.label,
         "--ccusage-runner",
         ccusage_runner,
+        "--ccusage-package",
+        ccusage_package,
     ]
+    if timezone:
+        command.extend(["--timezone", timezone])
     try:
         completed = subprocess.run(
             command,
@@ -409,7 +505,12 @@ def run_remote_collect(
 
 
 def collect_host(
-    spec: HostSpec, cache_dir: Path, timeout: int, ccusage_runner: str
+    spec: HostSpec,
+    cache_dir: Path,
+    timeout: int,
+    ccusage_runner: str,
+    timezone: str = "",
+    ccusage_package: str = DEFAULT_CCUSAGE_PACKAGE,
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     path = cache_path(cache_dir, spec.label)
     status = {
@@ -417,24 +518,30 @@ def collect_host(
         "target": spec.target,
         "status": "unknown",
         "cache": str(path),
+        "collected_at": "",
         "message": "",
     }
 
     if spec.is_local:
-        payload = collect_local(spec.label, ccusage_runner)
-        status["status"] = "updated"
-        atomic_write_json(path, payload)
-        return payload, status
-
-    payload, error = run_remote_collect(spec, timeout, ccusage_runner)
-    if payload is not None:
-        status["status"] = "updated"
-        atomic_write_json(path, payload)
-        return payload, status
+        fresh: dict[str, Any] | None = collect_local(spec.label, ccusage_runner, timezone, ccusage_package)
+        error = ""
+    else:
+        fresh, error = run_remote_collect(spec, timeout, ccusage_runner, timezone, ccusage_package)
 
     cached = load_json(path)
+    if fresh is not None:
+        fresh_count = len(fresh.get("records", []))
+        payload = merge_payload(cached, fresh)
+        status["status"] = "updated"
+        status["collected_at"] = str(payload.get("collected_at") or "")
+        if not fresh_count and cached is not None:
+            status["message"] = "no fresh records; kept ledger"
+        atomic_write_json(path, payload)
+        return payload, status
+
     if cached is not None:
         status["status"] = "cached"
+        status["collected_at"] = str(cached.get("collected_at") or "")
         status["message"] = error
         return cached, status
 
@@ -493,7 +600,6 @@ def aggregate_daily(
                 "model": key[6],
                 "account": key[7],
                 "records": 0,
-                "sessions": set(),
                 "hosts": set(),
                 "accounts": set(),
                 "input_tokens": 0,
@@ -506,9 +612,6 @@ def aggregate_daily(
             },
         )
         bucket["records"] += 1
-        if record.get("session_id"):
-            session_host = str(record.get("host") or record.get("host_label") or "")
-            bucket["sessions"].add(f"{session_host}:{record.get('session_id')}")
         if record.get("host"):
             bucket["hosts"].add(str(record.get("host")))
         account_bits = [str(record.get("account_label") or ""), str(record.get("account") or "")]
@@ -529,7 +632,6 @@ def aggregate_daily(
     daily = []
     for bucket in buckets.values():
         row = dict(bucket)
-        row["sessions"] = len(bucket["sessions"])
         row["hosts"] = ",".join(sorted(bucket["hosts"]))
         row["accounts"] = ",".join(sorted(bucket["accounts"]))
         row["cost_usd"] = round(row["cost_usd"], 10)
@@ -584,7 +686,6 @@ def write_daily_csv(path: Path, records: list[dict[str, Any]]) -> None:
         "hosts",
         "accounts",
         "records",
-        "sessions",
         "input_tokens",
         "output_tokens",
         "cache_creation_tokens",
@@ -609,143 +710,10 @@ def html_escape(value: Any) -> str:
     return html.escape(str(value), quote=True)
 
 
-def add_to_bucket(bucket: dict[str, Any], record: dict[str, Any]) -> None:
-    bucket["records"] = as_int(bucket.get("records")) + as_int(record.get("records", 1))
-    bucket["sessions"] = as_int(bucket.get("sessions")) + as_int(record.get("sessions", 0))
-    for field in (
-        "input_tokens",
-        "output_tokens",
-        "cache_creation_tokens",
-        "cache_read_tokens",
-        "reasoning_tokens",
-        "total_tokens",
-    ):
-        bucket[field] = as_int(bucket.get(field)) + as_int(record.get(field))
-    bucket["cost_usd"] = as_float(bucket.get("cost_usd")) + as_float(record.get("cost_usd"))
-
-
 def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> dict[str, Any]:
-    day_buckets: dict[str, dict[str, Any]] = {}
-    model_buckets: dict[tuple[str, str, str], dict[str, Any]] = {}
-    service_buckets: dict[tuple[str, str], dict[str, Any]] = {}
-    hosts_seen: set[str] = set()
-    accounts_seen: set[str] = set()
-
-    for record in daily:
-        date = str(record.get("date") or "")
-        if date:
-            day_bucket = day_buckets.setdefault(
-                date,
-                {
-                    "date": date,
-                    "records": 0,
-                    "sessions": 0,
-                    "input_tokens": 0,
-                    "output_tokens": 0,
-                    "cache_creation_tokens": 0,
-                    "cache_read_tokens": 0,
-                    "reasoning_tokens": 0,
-                    "total_tokens": 0,
-                    "cost_usd": 0.0,
-                },
-            )
-            add_to_bucket(day_bucket, record)
-
-        service = str(record.get("service") or record.get("source") or "unknown")
-        source = str(record.get("source") or "unknown")
-        provider = str(record.get("provider") or "")
-        model = str(record.get("model") or "unknown")
-        model_key = (service, provider, model)
-        model_bucket = model_buckets.setdefault(
-            model_key,
-            {
-                "service": service,
-                "provider": provider,
-                "model": model,
-                "records": 0,
-                "sessions": 0,
-                "days": set(),
-                "sources": set(),
-                "hosts": set(),
-                "accounts": set(),
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cache_creation_tokens": 0,
-                "cache_read_tokens": 0,
-                "reasoning_tokens": 0,
-                "total_tokens": 0,
-                "cost_usd": 0.0,
-            },
-        )
-        add_to_bucket(model_bucket, record)
-        if date:
-            model_bucket["days"].add(date)
-        model_bucket["sources"].add(source)
-
-        for host in str(record.get("hosts") or record.get("host") or "").split(","):
-            if host and host != "all":
-                model_bucket["hosts"].add(host)
-                hosts_seen.add(host)
-        for account in str(record.get("accounts") or record.get("account_label") or "").split(","):
-            if account and account != "all":
-                model_bucket["accounts"].add(account)
-                accounts_seen.add(account)
-
-        service_key = (source, service)
-        service_bucket = service_buckets.setdefault(
-            service_key,
-            {
-                "source": source,
-                "service": service,
-                "records": 0,
-                "sessions": 0,
-                "input_tokens": 0,
-                "output_tokens": 0,
-                "cache_creation_tokens": 0,
-                "cache_read_tokens": 0,
-                "reasoning_tokens": 0,
-                "total_tokens": 0,
-                "cost_usd": 0.0,
-            },
-        )
-        add_to_bucket(service_bucket, record)
-
-    days = sorted(day_buckets.values(), key=lambda item: item["date"])
-    models = []
-    for bucket in model_buckets.values():
-        item = dict(bucket)
-        item["days"] = len(bucket["days"])
-        item["sources"] = sorted(bucket["sources"])
-        item["hosts"] = sorted(bucket["hosts"])
-        item["accounts"] = sorted(bucket["accounts"])
-        item["cost_usd"] = round(item["cost_usd"], 6)
-        models.append(item)
-    models.sort(key=lambda item: item["total_tokens"], reverse=True)
-
-    services = []
-    for bucket in service_buckets.values():
-        item = dict(bucket)
-        item["cost_usd"] = round(item["cost_usd"], 6)
-        services.append(item)
-    services.sort(key=lambda item: item["total_tokens"], reverse=True)
-
-    totals = {
-        "records": sum(as_int(day.get("records")) for day in days),
-        "sessions": sum(as_int(day.get("sessions")) for day in days),
-        "input_tokens": sum(as_int(day.get("input_tokens")) for day in days),
-        "output_tokens": sum(as_int(day.get("output_tokens")) for day in days),
-        "cache_creation_tokens": sum(as_int(day.get("cache_creation_tokens")) for day in days),
-        "cache_read_tokens": sum(as_int(day.get("cache_read_tokens")) for day in days),
-        "reasoning_tokens": sum(as_int(day.get("reasoning_tokens")) for day in days),
-        "total_tokens": sum(as_int(day.get("total_tokens")) for day in days),
-        "cost_usd": round(sum(as_float(day.get("cost_usd")) for day in days), 6),
-        "active_models": len(models),
-        "latest_date": days[-1]["date"] if days else "",
-        "first_date": days[0]["date"] if days else "",
-        "hosts": len(hosts_seen),
-        "accounts": len(accounts_seen),
-    }
-
+    # The dashboard recomputes every aggregate client-side from `rows` (the date
+    # range and host filters need that anyway), so only rows and host statuses
+    # are embedded.
     rows = []
     for record in sorted(daily, key=lambda item: (item.get("date") or "", item.get("source") or "", item.get("model") or "")):
         rows.append(
@@ -759,7 +727,6 @@ def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> 
                 "hosts": str(record.get("hosts") or record.get("host") or ""),
                 "accounts": str(record.get("accounts") or ""),
                 "records": as_int(record.get("records")),
-                "sessions": as_int(record.get("sessions")),
                 "input_tokens": as_int(record.get("input_tokens")),
                 "output_tokens": as_int(record.get("output_tokens")),
                 "cache_creation_tokens": as_int(record.get("cache_creation_tokens")),
@@ -772,10 +739,6 @@ def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> 
 
     return {
         "generated_at": combined.get("generated_at") or utc_now(),
-        "summary": totals,
-        "days": days,
-        "models": models[:30],
-        "services": services,
         "rows": rows,
         "hosts": combined.get("statuses", []),
     }
@@ -823,14 +786,15 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .stat { padding: 18px 14px 16px; border-right: 1px solid var(--rule); min-width: 0; }
 .stat:last-child { border-right: 0; }
 .value { font: 29px/.95 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: -.05em; white-space: nowrap; }
-.rangebar { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 16px 0; border-bottom: 1px solid var(--rule); }
-.presets { display: flex; flex-wrap: wrap; gap: 8px; }
-.rangebar button, .rangebar input, .rangebar select { color: var(--ink); background: var(--paper); border: 1px solid var(--rule); padding: 8px 10px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-.rangebar select { min-width: 180px; max-height: 120px; }
+.rangebar { display: flex; flex-wrap: wrap; align-items: center; gap: 14px 26px; padding: 16px 0; border-bottom: 1px solid var(--rule); }
+.filter-group { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.presets, .chips { display: flex; flex-wrap: wrap; gap: 8px; }
+.rangebar button, .rangebar input { color: var(--muted); background: var(--paper); border: 1px solid var(--rule); padding: 8px 12px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; border-radius: 999px; }
+.rangebar input { color: var(--ink); }
 .rangebar button { cursor: pointer; text-transform: uppercase; letter-spacing: .08em; }
-.rangebar button.active, .rangebar button:hover, .rangebar input:focus, .rangebar select:focus { border-color: var(--gold); outline: 0; }
-.custom-range { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
-.range-readout { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin-left: 6px; }
+.rangebar button.active { border-color: var(--gold); color: var(--ink); }
+.rangebar button:hover, .rangebar input:focus { border-color: var(--gold); outline: 0; }
+.range-readout { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 28px; margin-top: 30px; align-items: start; }
 .panel { border-top: 1px solid var(--rule-strong); padding-top: 14px; min-width: 0; }
 .flow-panel { overflow: hidden; padding-bottom: 8px; }
@@ -876,9 +840,16 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .tokenmax-metric { border-left: 1px solid var(--rule); padding-left: 10px; }
 .tokenmax-metric strong { display: block; font: 22px/.95 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: -.04em; }
 .tokenmax-line { margin-top: 12px; color: var(--gold); font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-table { width: 100%; border-collapse: collapse; font: 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.table-tools { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.table-tools input { color: var(--ink); background: var(--paper); border: 1px solid var(--rule); padding: 8px 14px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; border-radius: 999px; flex: 1 1 240px; max-width: 380px; }
+.table-tools input:focus { border-color: var(--gold); outline: 0; }
+.table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+table { width: 100%; min-width: 640px; border-collapse: collapse; font: 13px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 th, td { padding: 10px 8px; border-bottom: 1px solid var(--rule); vertical-align: top; }
 th { text-align: left; }
+th.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+th.sortable:hover { color: var(--ink); }
+th.sortable.asc::after { content: " \\2191"; } th.sortable.desc::after { content: " \\2193"; }
 td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .model-name { color: var(--ink); font-family: Georgia, "Times New Roman", serif; font-size: 15px; }
 .meta { color: var(--muted); font-size: 11px; margin-top: 3px; }
@@ -886,30 +857,55 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .host { border: 1px solid var(--rule); padding: 7px 9px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
 .host.updated .dot { color: var(--green); } .host.cached .dot { color: var(--gold); } .host.missing .dot { color: var(--red); }
 .note { color: var(--muted); font-size: 13px; line-height: 1.45; margin-top: 12px; }
-@media (max-width: 900px) { .mast, .grid, .rangebar, .heatmaps { display: block; } .heatmap-wrap { margin-top: 20px; } .custom-range { margin-top: 12px; } .generated { text-align: left; margin-top: 14px; } .stats { grid-template-columns: repeat(2, 1fr); } .stat:nth-child(2n) { border-right: 0; } }
+.coverage { display: none; border: 1px solid var(--gold); color: var(--gold); padding: 10px 12px; margin-top: 14px; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.coverage.visible { display: block; }
+@media (max-width: 900px) {
+  .mast, .grid, .heatmaps { display: block; }
+  .generated { text-align: left; margin-top: 14px; max-width: none; }
+  .heatmap-wrap { margin-top: 20px; }
+  aside.panel { margin-top: 26px; }
+  .stats { grid-template-columns: repeat(2, 1fr); }
+  .stat:nth-child(2n) { border-right: 0; }
+}
+@media (max-width: 600px) {
+  main { padding-top: 20px; }
+  .stat { padding: 14px 10px 12px; }
+  .value { font-size: 21px; }
+  .chart { height: 240px; }
+  th, td { padding: 8px 6px; }
+  .rangebar button, .rangebar input, .table-tools input { padding: 10px 14px; }
+  .hovercard { max-width: 220px; }
+}
 </style>
 </head>
 <body>
 <main>
   <header class="mast">
     <div><div class="kicker">Personal instrument panel</div><h1>AI Usage<br>Ledger</h1></div>
-    <div class="generated"><div class="label">Generated</div><div id="generated"></div><p class="note">Accounts are merged by default. Cost is reported only when the source provides it.</p></div>
+    <div class="generated"><div class="label">Generated</div><div id="generated"></div><p class="note">Accounts are merged by default. Cost is an API-equivalent estimate from ccusage pricing, not billed spend.</p></div>
   </header>
   <section class="stats" id="stats" aria-label="Summary statistics"></section>
-  <section class="rangebar" aria-label="Date range selector">
-    <div class="presets" id="presets">
-      <button type="button" data-range="all" class="active">All</button>
-      <button type="button" data-range="7">7D</button>
-      <button type="button" data-range="30">30D</button>
-      <button type="button" data-range="90">90D</button>
-      <button type="button" data-range="365">1Y</button>
+  <div id="coverage" class="coverage" role="alert"></div>
+  <section class="rangebar" aria-label="Filters">
+    <div class="filter-group" aria-label="Date range presets">
+      <span class="label">Range</span>
+      <div class="presets" id="presets">
+        <button type="button" data-range="all" class="active">All</button>
+        <button type="button" data-range="7">7D</button>
+        <button type="button" data-range="30">30D</button>
+        <button type="button" data-range="90">90D</button>
+        <button type="button" data-range="365">1Y</button>
+      </div>
     </div>
-    <div class="custom-range">
+    <div class="filter-group" aria-label="Custom date range">
       <span class="label">From</span><input id="fromDate" type="date">
       <span class="label">To</span><input id="toDate" type="date">
-      <span class="label">Hosts</span><select id="hostFilter" multiple size="4"><option value="all" selected>All hosts</option></select>
-      <span class="range-readout" id="rangeReadout"></span>
     </div>
+    <div class="filter-group" aria-label="Host filter">
+      <span class="label">Hosts</span>
+      <div class="chips" id="hostFilter"></div>
+    </div>
+    <span class="range-readout" id="rangeReadout"></span>
   </section>
   <section class="grid">
     <div class="panel flow-panel">
@@ -918,7 +914,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         <label class="scale-control">Y scale <select id="tokenScale"><option value="log" selected>Log</option><option value="linear">Linear</option></select></label>
       </div>
       <div class="chart-body">
-        <div id="chart" class="chart" aria-label="Daily token bars and reported cost curve"></div>
+        <div id="chart" class="chart" aria-label="Daily token bars and estimated cost curve"></div>
       </div>
       <div class="legend">
         <span><i class="swatch" style="background:var(--in)"></i>input</span>
@@ -926,7 +922,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         <span><i class="swatch" style="background:var(--cw)"></i>cache write</span>
         <span><i class="swatch" style="background:var(--cr)"></i>cache read</span>
         <span><i class="swatch" style="background:var(--rz)"></i>reasoning</span>
-        <span><i class="swatch line" style="background:var(--gold)"></i>reported cost</span>
+        <span><i class="swatch line" style="background:var(--gold)"></i>est. cost</span>
       </div>
     </div>
     <aside class="panel">
@@ -938,7 +934,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         <div id="tokenmax" class="tokenmax-grid"></div>
         <div id="tokenmaxLine" class="tokenmax-line"></div>
       </div>
-      <p class="note">Provider mix groups usage by the model provider family: OpenAI, Claude, Gemini, Grok, opencode, and other ccusage-reported providers.</p>
+      <p class="note">Provider mix groups usage by the inferred model family (Claude, OpenAI, Gemini, Grok, …) regardless of which agent routed it; hover a segment to see the routing agents.</p>
     </aside>
   </section>
   <section class="heatmaps" aria-label="Daily heatmaps">
@@ -948,17 +944,31 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
       <div class="heatmap-legend"><span>less</span><i class="cell"></i><i class="cell l1"></i><i class="cell l2"></i><i class="cell l3"></i><i class="cell l4"></i><span>more</span></div>
     </div>
     <div class="heatmap-wrap">
-      <div class="heatmap-head"><div class="heatmap-title">Daily Cost Measure</div><div id="costHeatMax" class="heatmap-max"></div></div>
+      <div class="heatmap-head"><div class="heatmap-title">Daily Estimated Cost</div><div id="costHeatMax" class="heatmap-max"></div></div>
       <div class="heatmap-scroll"><div id="costHeatMonths" class="heat-months"></div><div id="costHeatmap" class="heatmap"></div></div>
       <div class="heatmap-legend"><span>less</span><i class="cell cost"></i><i class="cell cost l1"></i><i class="cell cost l2"></i><i class="cell cost l3"></i><i class="cell cost l4"></i><span>more</span></div>
     </div>
   </section>
   <section class="panel" style="margin-top:42px">
     <h2>Top Models</h2>
-    <table>
-      <thead><tr><th>Model</th><th class="num">Days</th><th class="num">Input</th><th class="num">Output</th><th class="num">Cache</th><th class="num">Total</th><th class="num">Cost</th></tr></thead>
-      <tbody id="models"></tbody>
-    </table>
+    <div class="table-tools">
+      <input id="modelSearch" type="search" placeholder="Filter by model, provider, agent, or host…" aria-label="Filter models">
+      <span class="range-readout" id="modelCount"></span>
+    </div>
+    <div class="table-scroll">
+      <table>
+        <thead><tr>
+          <th class="sortable" data-key="model">Model</th>
+          <th class="num sortable" data-key="days">Days</th>
+          <th class="num sortable" data-key="input_tokens">Input</th>
+          <th class="num sortable" data-key="output_tokens">Output</th>
+          <th class="num sortable" data-key="cache">Cache</th>
+          <th class="num sortable" data-key="total_tokens">Total</th>
+          <th class="num sortable desc" data-key="cost_usd">Est. Cost</th>
+        </tr></thead>
+        <tbody id="models"></tbody>
+      </table>
+    </div>
   </section>
   <section class="panel" style="margin-top:30px">
     <h2>Host Cache Status</h2>
@@ -966,7 +976,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
   </section>
 </main>
 <div id="hovercard" class="hovercard"></div>
-<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+__D3_SCRIPT__
 <script id="usage-data" type="application/json">__DATA__</script>
 <script>
 const D = JSON.parse(document.getElementById('usage-data').textContent);
@@ -983,7 +993,7 @@ function providerCostLines(day) {
 }
 function node(tag, cls, text) { const el = document.createElement(tag); if (cls) el.className = cls; if (text !== undefined) el.textContent = text; return el; }
 function clear(id) { const el = document.getElementById(id); while (el.firstChild) el.removeChild(el.firstChild); return el; }
-function addTotals(target, row) { fields.concat(['total_tokens']).forEach(f => target[f] = Number(target[f] || 0) + Number(row[f] || 0)); target.cost_usd = Number(target.cost_usd || 0) + Number(row.cost_usd || 0); target.records = Number(target.records || 0) + Number(row.records || 0); target.sessions = Number(target.sessions || 0) + Number(row.sessions || 0); }
+function addTotals(target, row) { fields.concat(['total_tokens']).forEach(f => target[f] = Number(target[f] || 0) + Number(row[f] || 0)); target.cost_usd = Number(target.cost_usd || 0) + Number(row.cost_usd || 0); target.records = Number(target.records || 0) + Number(row.records || 0); }
 function dateAdd(date, delta) { const d = new Date(date + 'T00:00:00Z'); d.setUTCDate(d.getUTCDate() + delta); return d.toISOString().slice(0,10); }
 function availableDates() { return [...new Set((D.rows || []).map(r => r.date).filter(Boolean))].sort(); }
 function rowHosts(row) { return (row.host || row.hosts || '').split(',').map(v => v.trim()).filter(Boolean); }
@@ -992,7 +1002,6 @@ function selectedRows() { return (D.rows || []).filter(r => {
   return (!state.from || r.date >= state.from) && (!state.to || r.date <= state.to) && hostOk;
 }); }
 function providerGroup(row) {
-  if (row.source === 'opencode') return 'opencode';
   if (row.service === 'codex') return 'openai';
   return row.service || row.provider || row.source || 'unknown';
 }
@@ -1001,30 +1010,30 @@ function derive(rows) {
   rows.forEach(row => {
     if (!row.date) return;
     const provider = providerGroup(row);
-    if (!daysMap.has(row.date)) daysMap.set(row.date, {date: row.date, records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, provider_costs:{}});
+    if (!daysMap.has(row.date)) daysMap.set(row.date, {date: row.date, records:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, provider_costs:{}});
     const dayBucket = daysMap.get(row.date);
     addTotals(dayBucket, row);
     dayBucket.provider_costs[provider] = Number(dayBucket.provider_costs[provider] || 0) + Number(row.cost_usd || 0);
     const modelKey = [row.service, row.provider, row.model].join('\u0000');
-    if (!modelsMap.has(modelKey)) modelsMap.set(modelKey, {service: row.service, provider: row.provider, model: row.model, days: new Set(), sources: new Set(), hosts: new Set(), accounts: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
+    if (!modelsMap.has(modelKey)) modelsMap.set(modelKey, {service: row.service, provider: row.provider, model: row.model, days: new Set(), sources: new Set(), hosts: new Set(), accounts: new Set(), records:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
     const model = modelsMap.get(modelKey); addTotals(model, row); model.days.add(row.date); model.sources.add(row.source); (row.hosts || '').split(',').filter(Boolean).forEach(v => model.hosts.add(v)); (row.accounts || '').split(',').filter(Boolean).forEach(v => model.accounts.add(v));
-    if (!servicesMap.has(provider)) servicesMap.set(provider, {provider, sources: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
+    if (!servicesMap.has(provider)) servicesMap.set(provider, {provider, sources: new Set(), records:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
     const serviceBucket = servicesMap.get(provider);
     serviceBucket.sources.add(row.source);
     addTotals(serviceBucket, row);
   });
   const days = [...daysMap.values()].sort((a,b) => a.date.localeCompare(b.date));
-  const models = [...modelsMap.values()].map(m => ({...m, days: m.days.size, sources: [...m.sources].sort(), hosts: [...m.hosts].sort(), accounts: [...m.accounts].sort()})).sort((a,b) => b.total_tokens - a.total_tokens);
-  const services = [...servicesMap.values()].map(s => ({...s, sources: [...s.sources].sort()})).sort((a,b) => b.total_tokens - a.total_tokens);
-  const summary = {records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, active_models: models.length, first_date: days[0]?.date || '', latest_date: days.at(-1)?.date || ''};
+  const models = [...modelsMap.values()].map(m => ({...m, days: m.days.size, sources: [...m.sources].sort(), hosts: [...m.hosts].sort(), accounts: [...m.accounts].sort()})).sort((a,b) => (b.cost_usd - a.cost_usd) || (b.total_tokens - a.total_tokens));
+  const services = [...servicesMap.values()].map(s => ({...s, sources: [...s.sources].sort()})).sort((a,b) => (b.cost_usd - a.cost_usd) || (b.total_tokens - a.total_tokens));
+  const summary = {records:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, active_models: models.length, first_date: days[0]?.date || '', latest_date: days.at(-1)?.date || ''};
   days.forEach(day => addTotals(summary, day));
   return {days, models, services, summary};
 }
 function renderStats(summary) {
   document.getElementById('generated').textContent = D.generated_at || 'unknown';
   const stats = [
-    ['total', fmt(summary.total_tokens)], ['input', fmt(summary.input_tokens)], ['output', fmt(summary.output_tokens)],
-    ['cache read', fmt(summary.cache_read_tokens)], ['cache write', fmt(summary.cache_creation_tokens)], ['cost', usd(summary.cost_usd)],
+    ['est. cost', usd(summary.cost_usd)], ['output', fmt(summary.output_tokens)], ['input', fmt(summary.input_tokens)],
+    ['cache read', fmt(summary.cache_read_tokens)], ['cache write', fmt(summary.cache_creation_tokens)], ['total', fmt(summary.total_tokens)],
     ['models', fmt(summary.active_models)], ['latest', summary.latest_date || 'n/a']
   ];
   const root = clear('stats');
@@ -1061,7 +1070,7 @@ function renderChart(days) {
     return;
   }
   const root = d3.select(rootNode);
-  const width = Math.max(760, rootNode.clientWidth || 900);
+  const width = Math.max(420, rootNode.clientWidth || 900);
   const height = 320;
   const margin = {top: 18, right: 72, bottom: 38, left: 70};
   const innerWidth = width - margin.left - margin.right;
@@ -1131,7 +1140,7 @@ function renderChart(days) {
     .attr('cx', d => (x(d.date) || margin.left) + x.bandwidth() / 2)
     .attr('cy', d => costValue(Number(d.cost_usd || 0)))
     .attr('r', 2.4)
-    .append('title').text(d => `${d.date} · ${usd(d.cost_usd)} reported cost · ${fmt(d.total_tokens)} tokens`);
+    .append('title').text(d => `${d.date} · ${usd(d.cost_usd)} est. cost · ${fmt(d.total_tokens)} tokens`);
   const focus = svg.append('g').attr('class', 'chart-focus').style('display', 'none');
   focus.append('line').attr('y1', margin.top).attr('y2', barBase).attr('stroke', 'var(--gold)').attr('stroke-width', 1).attr('stroke-dasharray', '3 3');
   focus.append('circle').attr('r', 4).attr('fill', 'var(--paper)').attr('stroke', 'var(--gold)').attr('stroke-width', 2);
@@ -1158,7 +1167,7 @@ function renderChart(days) {
         `${fmt(day.total_tokens)} total tokens`,
         `${fmt(day.input_tokens)} in · ${fmt(day.output_tokens)} out`,
         `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache`,
-        `${usd(day.cost_usd)} reported cost`,
+        `${usd(day.cost_usd)} est. cost`,
         ...providerCostLines(day),
         `${state.tokenScale} scale`,
       ]);
@@ -1239,7 +1248,7 @@ function renderHeatmap(rootId, monthsId, maxId, days, field, formatter, costMode
     const level = heatLevel(value, max);
     const cell = node('i', `cell${costMode ? ' cost' : ''}${level ? ' l' + level : ''}`);
     const lines = costMode
-      ? [date, `${formatter(value)} reported cost`, `${fmt(day.total_tokens || 0)} tokens`, ...providerCostLines(day)]
+      ? [date, `${formatter(value)} est. cost`, `${fmt(day.total_tokens || 0)} tokens`, ...providerCostLines(day)]
       : [date, `${formatter(value)} total tokens`, `${fmt(day.input_tokens || 0)} in · ${fmt(day.output_tokens || 0)} out`, `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache · ${usd(day.cost_usd || 0)}`, ...providerCostLines(day)];
     cell.setAttribute('aria-label', lines.join(' · '));
     cell.addEventListener('mouseenter', event => showHover(event, lines));
@@ -1264,22 +1273,62 @@ function routeSummary(row) {
   const service = row.service || '';
   return [service, via, hostSummary(row.hosts)].filter(Boolean).join(' · ');
 }
+let tableState = { key: 'cost_usd', dir: -1, query: '' };
+let lastModels = [];
+function modelSortValue(row, key) {
+  if (key === 'model') return (row.model || '').toLowerCase();
+  if (key === 'cache') return Number(row.cache_creation_tokens || 0) + Number(row.cache_read_tokens || 0);
+  return Number(row[key] || 0);
+}
+function syncSortHeaders() {
+  document.querySelectorAll('th.sortable').forEach(th => {
+    th.classList.toggle('asc', th.dataset.key === tableState.key && tableState.dir === 1);
+    th.classList.toggle('desc', th.dataset.key === tableState.key && tableState.dir === -1);
+  });
+}
 function renderModels(models) {
   const body = clear('models');
-  models.slice(0, 30).forEach(row => {
+  const query = tableState.query.trim().toLowerCase();
+  const filtered = models.filter(row => !query || [row.model, row.service, row.provider, (row.sources || []).join(' '), (row.hosts || []).join(' '), (row.accounts || []).join(' ')].join(' ').toLowerCase().includes(query));
+  const sorted = [...filtered].sort((a, b) => {
+    const va = modelSortValue(a, tableState.key), vb = modelSortValue(b, tableState.key);
+    return (va < vb ? -1 : va > vb ? 1 : 0) * tableState.dir;
+  });
+  sorted.forEach(row => {
     const tr = document.createElement('tr');
     const name = document.createElement('td');
     name.title = `sources: ${(row.sources || []).join(', ')}; hosts: ${(row.hosts || []).join(', ')}; accounts: ${(row.accounts || []).join(', ')}`;
     name.append(node('div','model-name',row.model || 'unknown'));
     name.append(node('div','meta',routeSummary(row)));
     tr.append(name);
-    [['days',fmt(row.days)],['input',fmt(row.input_tokens)],['output',fmt(row.output_tokens)],['cache',fmt(Number(row.cache_creation_tokens || 0)+Number(row.cache_read_tokens || 0))],['total',fmt(row.total_tokens)],['cost',usd(row.cost_usd)]].forEach(([, value]) => tr.append(node('td','num',value)));
+    [fmt(row.days), fmt(row.input_tokens), fmt(row.output_tokens), fmt(Number(row.cache_creation_tokens || 0)+Number(row.cache_read_tokens || 0)), fmt(row.total_tokens), usd(row.cost_usd)].forEach(value => tr.append(node('td','num',value)));
     body.append(tr);
   });
+  document.getElementById('modelCount').textContent = query ? `${sorted.length} of ${models.length} models` : `${models.length} models`;
+  syncSortHeaders();
 }
 function renderHosts() {
   const root = clear('hosts');
-  (D.hosts || []).forEach(row => { const status = row.status || 'missing'; const item = node('div','host '+status); item.title = row.message || row.cache || ''; item.append(node('span','dot', status === 'updated' ? '● ' : status === 'cached' ? '◐ ' : '○ ')); item.append(document.createTextNode(`${row.host || 'host'} · ${status}`)); root.append(item); });
+  (D.hosts || []).forEach(row => {
+    const status = row.status || 'missing';
+    const stale = status === 'cached' && row.collected_at ? ` (as of ${String(row.collected_at).slice(0, 10)})` : '';
+    const item = node('div','host '+status);
+    item.title = row.message || row.cache || '';
+    item.append(node('span','dot', status === 'updated' ? '● ' : status === 'cached' ? '◐ ' : '○ '));
+    item.append(document.createTextNode(`${row.host || 'host'} · ${status}${stale}`));
+    root.append(item);
+  });
+}
+function renderCoverage() {
+  const banner = document.getElementById('coverage');
+  const issues = (D.hosts || []).filter(row => row.status && row.status !== 'updated');
+  if (!issues.length) { banner.classList.remove('visible'); banner.textContent = ''; return; }
+  const parts = issues.map(row => {
+    if (row.status === 'cached') return `${row.host}: stale cache${row.collected_at ? ' from ' + String(row.collected_at).slice(0, 10) : ''}`;
+    return `${row.host}: no data (${row.message || 'unreachable'})`;
+  });
+  banner.textContent = `⚠ Incomplete coverage — ${parts.join(' · ')}`;
+  banner.classList.add('visible');
 }
 function applyRange(preset) {
   const dates = availableDates();
@@ -1301,20 +1350,32 @@ function applyCustomRange() {
   renderAll();
 }
 function populateHostFilter() {
-  const select = document.getElementById('hostFilter');
-  const hosts = [...new Set((D.rows || []).flatMap(rowHosts))].sort();
-  hosts.forEach(host => select.append(node('option', '', host)));
+  const root = clear('hostFilter');
+  const hosts = ['all', ...[...new Set((D.rows || []).flatMap(rowHosts))].sort()];
+  hosts.forEach(host => {
+    const chip = node('button', 'chip', host === 'all' ? 'All' : host);
+    chip.type = 'button';
+    chip.dataset.host = host;
+    chip.addEventListener('click', () => toggleHostChip(host));
+    root.append(chip);
+  });
+  syncHostChips();
 }
-function applyHostFilter() {
-  const select = document.getElementById('hostFilter');
-  const values = [...select.selectedOptions].map(option => option.value);
-  if (values.includes('all') || values.length === 0) {
+function toggleHostChip(host) {
+  if (host === 'all') {
     state.hosts = ['all'];
-    [...select.options].forEach(option => option.selected = option.value === 'all');
   } else {
-    state.hosts = values;
+    const chosen = new Set(state.hosts.filter(value => value !== 'all'));
+    if (chosen.has(host)) chosen.delete(host); else chosen.add(host);
+    state.hosts = chosen.size ? [...chosen] : ['all'];
   }
+  syncHostChips();
   renderAll();
+}
+function syncHostChips() {
+  document.querySelectorAll('#hostFilter .chip').forEach(chip => {
+    chip.classList.toggle('active', state.hosts.includes(chip.dataset.host));
+  });
 }
 function applyTokenScale() {
   state.tokenScale = document.getElementById('tokenScale').value || 'log';
@@ -1322,7 +1383,8 @@ function applyTokenScale() {
 }
 function renderAll() {
   const derived = derive(selectedRows());
-  renderStats(derived.summary); renderChart(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderHeatmaps(derived.days); renderModels(derived.models); renderHosts();
+  lastModels = derived.models;
+  renderStats(derived.summary); renderChart(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderHeatmaps(derived.days); renderModels(lastModels); renderHosts();
   const readout = document.getElementById('rangeReadout');
   const hostText = state.hosts.includes('all') ? 'all hosts' : state.hosts.join(', ');
   readout.textContent = `${derived.days.length} days · ${derived.summary.first_date || 'n/a'} to ${derived.summary.latest_date || 'n/a'} · ${hostText}`;
@@ -1330,9 +1392,18 @@ function renderAll() {
 document.querySelectorAll('#presets button').forEach(button => button.addEventListener('click', () => applyRange(button.dataset.range)));
 document.getElementById('fromDate').addEventListener('change', applyCustomRange);
 document.getElementById('toDate').addEventListener('change', applyCustomRange);
-document.getElementById('hostFilter').addEventListener('change', applyHostFilter);
 document.getElementById('tokenScale').addEventListener('change', applyTokenScale);
+document.getElementById('modelSearch').addEventListener('input', event => { tableState.query = event.target.value || ''; renderModels(lastModels); });
+document.querySelectorAll('th.sortable').forEach(th => th.addEventListener('click', () => {
+  const key = th.dataset.key;
+  if (tableState.key === key) tableState.dir = -tableState.dir;
+  else { tableState.key = key; tableState.dir = key === 'model' ? 1 : -1; }
+  renderModels(lastModels);
+}));
+let resizeTimer = null;
+window.addEventListener('resize', () => { clearTimeout(resizeTimer); resizeTimer = setTimeout(renderAll, 150); });
 populateHostFilter();
+renderCoverage();
 applyRange('all');
 </script>
 </body>
@@ -1340,11 +1411,33 @@ applyRange('all');
 """
 
 
-def write_html(path: Path, combined: dict[str, Any], daily: list[dict[str, Any]]) -> None:
+def d3_script_tag(cache_dir: Path) -> str:
+    """Inline a pinned d3 build so the dashboard works offline; fall back to the CDN."""
+    vendor = cache_dir / f"d3-{D3_VERSION}.min.js"
+    source = ""
+    if vendor.exists():
+        try:
+            source = vendor.read_text(encoding="utf-8")
+        except OSError:
+            source = ""
+    if not source:
+        try:
+            with urllib.request.urlopen(D3_URL, timeout=30) as response:
+                source = response.read().decode("utf-8")
+        except (urllib.error.URLError, OSError, TimeoutError) as exc:
+            eprint(f"Warning: could not fetch d3 for inlining ({exc}); dashboard will use the CDN.")
+            return f'<script src="{D3_URL}"></script>'
+        vendor.parent.mkdir(parents=True, exist_ok=True)
+        vendor.write_text(source, encoding="utf-8")
+    # Guard against the parser closing our tag early if the payload contains "</script".
+    return "<script>" + source.replace("</script", "<\\/script") + "</script>"
+
+
+def write_html(path: Path, combined: dict[str, Any], daily: list[dict[str, Any]], cache_dir: Path) -> None:
     dashboard_daily = aggregate_daily(combined["records"], split_hosts=True, split_accounts=False)
     payload = dashboard_payload(combined, dashboard_daily or daily)
     rendered = HTML_TEMPLATE.replace("__DATA__", json_for_script(payload))
-    rendered = rendered.replace("AI Usage Ledger", html_escape("AI Usage Ledger"), 1)
+    rendered = rendered.replace("__D3_SCRIPT__", d3_script_tag(cache_dir))
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(rendered, encoding="utf-8")
@@ -1395,16 +1488,47 @@ def parse_args() -> argparse.Namespace:
         default="auto",
         help="ccusage runner: auto uses npx ccusage@latest or installed ccusage.",
     )
+    parser.add_argument(
+        "--ccusage-package",
+        default=DEFAULT_CCUSAGE_PACKAGE,
+        help=f"npm spec for the npx runner, e.g. ccusage@17.2.0 to pin. Default {DEFAULT_CCUSAGE_PACKAGE}.",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="",
+        help="Timezone for ccusage daily buckets (e.g. Asia/Kolkata). Set it uniformly so days align across hosts; default is each machine's local timezone.",
+    )
+    parser.add_argument(
+        "--parallel",
+        type=int,
+        default=4,
+        help="Number of hosts to collect concurrently. Default 4; use 1 to collect sequentially.",
+    )
     parser.add_argument("--json-only", action="store_true", help="Do not write CSV output.")
-    parser.add_argument("--collect-local", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--host-label", default="", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--collect-local",
+        action="store_true",
+        help="Collect this machine only and print the payload to stdout. Pair with --collect-output for push-style cron collection into a synced cache directory.",
+    )
+    parser.add_argument(
+        "--collect-output",
+        type=Path,
+        help="With --collect-local: merge the collection into this ledger file (e.g. a synced cache dir's <label>.json) instead of printing JSON.",
+    )
+    parser.add_argument("--host-label", default="", help="Host label for --collect-local payloads. Defaults to the short hostname.")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     if args.collect_local:
-        print(json.dumps(collect_local(args.host_label, args.ccusage_runner), sort_keys=True))
+        payload = collect_local(args.host_label, args.ccusage_runner, args.timezone, args.ccusage_package)
+        if args.collect_output:
+            merged = merge_payload(load_json(args.collect_output), payload)
+            atomic_write_json(args.collect_output, merged)
+            eprint(f"Merged {len(payload.get('records', []))} fresh records into {args.collect_output}")
+        else:
+            print(json.dumps(payload, sort_keys=True))
         return 0
 
     script_dir = Path(__file__).resolve().parent
@@ -1429,10 +1553,37 @@ def main() -> int:
     if not specs:
         raise SystemExit("No hosts selected. Use --host, --inventory, or omit --no-local.")
 
+    workers = max(1, min(args.parallel, len(specs)))
+    results: list[tuple[dict[str, Any] | None, dict[str, Any]]] = []
+    if workers == 1:
+        results = [
+            collect_host(spec, cache_dir, args.ssh_timeout, args.ccusage_runner, args.timezone, args.ccusage_package)
+            for spec in specs
+        ]
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(
+                    collect_host, spec, cache_dir, args.ssh_timeout, args.ccusage_runner, args.timezone, args.ccusage_package
+                )
+                for spec in specs
+            ]
+            results = [future.result() for future in futures]
+
     host_payloads: list[tuple[HostSpec, dict[str, Any], bool]] = []
     statuses: list[dict[str, Any]] = []
-    for spec in specs:
-        payload, status = collect_host(spec, cache_dir, args.ssh_timeout, args.ccusage_runner)
+    machines_seen: dict[str, str] = {}
+    for spec, (payload, status) in zip(specs, results):
+        if payload is not None:
+            mid = str(payload.get("machine_id") or "")
+            if mid and mid in machines_seen:
+                status["status"] = "duplicate"
+                status["message"] = f"same machine as {machines_seen[mid]}; skipped to avoid double counting"
+                statuses.append(status)
+                eprint(f"{spec.label}: skipped ({status['message']})")
+                continue
+            if mid:
+                machines_seen[mid] = spec.label
         statuses.append(status)
         if payload is None:
             eprint(f"{spec.label}: no data ({status.get('message')})")
@@ -1467,7 +1618,7 @@ def main() -> int:
         if not args.json_only:
             write_daily_csv(args.daily_csv, daily)
     if not args.no_html:
-        write_html(args.html, combined, daily)
+        write_html(args.html, combined, daily, cache_dir)
 
     eprint(f"Wrote {args.output_json}")
     if not args.json_only:

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import argparse
 import csv
 import datetime as dt
-import glob
 import html
 import json
 import os
@@ -19,13 +18,11 @@ import re
 import shlex
 import shutil
 import socket
-import sqlite3
 import subprocess
 import sys
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 SCHEMA_VERSION = 1
 DEFAULT_CACHE_DIR = ".ai-usage-cache"
@@ -62,35 +59,6 @@ def iso_date(timestamp: str) -> str:
     return timestamp[:10]
 
 
-def normalize_timestamp(value: Any) -> str:
-    if value is None or value == "":
-        return ""
-    if isinstance(value, (int, float)):
-        seconds = float(value)
-        if seconds > 10_000_000_000:
-            seconds = seconds / 1000.0
-        try:
-            return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
-        except (OSError, OverflowError, ValueError):
-            return ""
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return ""
-        if text.isdigit():
-            return normalize_timestamp(int(text))
-        if text.endswith("Z"):
-            text = text[:-1] + "+00:00"
-        try:
-            parsed = dt.datetime.fromisoformat(text)
-        except ValueError:
-            return value.strip()
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=dt.timezone.utc)
-        return parsed.astimezone(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
-    return ""
-
-
 def as_int(value: Any) -> int:
     if value is None or value == "":
         return 0
@@ -107,33 +75,6 @@ def as_float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
-
-
-def get_nested(mapping: dict[str, Any], *keys: str) -> Any:
-    current: Any = mapping
-    for key in keys:
-        if not isinstance(current, dict):
-            return None
-        current = current.get(key)
-    return current
-
-
-def rel_home(path: Path) -> str:
-    try:
-        return "~/" + str(path.expanduser().resolve().relative_to(Path.home().resolve()))
-    except ValueError:
-        return str(path)
-
-
-def project_from_path(path: Path, marker: str) -> str:
-    parts = path.parts
-    try:
-        idx = parts.index(marker)
-    except ValueError:
-        return ""
-    if idx + 1 < len(parts):
-        return parts[idx + 1]
-    return ""
 
 
 def infer_service(source: str, provider: str, model: str) -> str:
@@ -191,69 +132,13 @@ def new_record(
     }
 
 
-def iter_jsonl(paths: Iterable[Path]) -> Iterable[tuple[Path, dict[str, Any]]]:
-    for path in paths:
-        try:
-            with path.open("r", encoding="utf-8", errors="replace") as handle:
-                for line in handle:
-                    if not line.strip():
-                        continue
-                    try:
-                        value = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if isinstance(value, dict):
-                        yield path, value
-        except OSError:
-            continue
-
-
-def collect_claude_raw(home: Path) -> list[dict[str, Any]]:
-    roots = [home / ".claude" / "projects", home / ".claude" / "transcripts"]
-    paths: list[Path] = []
-    for root in roots:
-        if root.exists():
-            paths.extend(root.rglob("*.jsonl"))
-
-    records: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for path, event in iter_jsonl(paths):
-        message = event.get("message")
-        if not isinstance(message, dict) or message.get("role") != "assistant":
-            continue
-        usage = message.get("usage")
-        if not isinstance(usage, dict):
-            continue
-        record_id = str(event.get("uuid") or event.get("requestId") or message.get("id") or f"{path}:{len(records)}")
-        if record_id in seen:
-            continue
-        seen.add(record_id)
-        records.append(
-            new_record(
-                source="claude_code",
-                timestamp=normalize_timestamp(event.get("timestamp")),
-                session_id=str(event.get("sessionId") or path.stem),
-                project=project_from_path(path, "projects"),
-                model=str(message.get("model") or ""),
-                input_tokens=as_int(usage.get("input_tokens")),
-                output_tokens=as_int(usage.get("output_tokens")),
-                cache_creation_tokens=as_int(usage.get("cache_creation_input_tokens")),
-                cache_read_tokens=as_int(usage.get("cache_read_input_tokens")),
-                source_path=rel_home(path),
-            )
-        )
-    return records
-
-
 def run_ccusage(mode: str, home: Path, extra_args: list[str] | None = None) -> dict[str, Any] | None:
-    if mode == "raw":
-        return None
     extra_args = extra_args or []
     command: list[str] | None = None
-    if mode in {"auto", "ccusage"} and shutil.which("ccusage"):
-        command = ["ccusage", "daily", "--json", *extra_args]
-    elif mode in {"auto", "npx"} and shutil.which("npx"):
+    if mode in {"auto", "npx"} and shutil.which("npx"):
         command = ["npx", "--yes", "ccusage@latest", "daily", "--json", *extra_args]
+    elif mode in {"auto", "ccusage"} and shutil.which("ccusage"):
+        command = ["ccusage", "daily", "--json", *extra_args]
     if command is None:
         return None
 
@@ -286,69 +171,6 @@ def run_ccusage(mode: str, home: Path, extra_args: list[str] | None = None) -> d
 
 def ccusage_day(day: dict[str, Any]) -> str:
     return str(day.get("date") or day.get("period") or "")
-
-
-def collect_claude_ccusage(home: Path, mode: str) -> list[dict[str, Any]]:
-    payload = run_ccusage(mode, home)
-    if payload is None:
-        return []
-    daily = payload.get("daily")
-    if not isinstance(daily, list):
-        return []
-
-    records: list[dict[str, Any]] = []
-    for day in daily:
-        if not isinstance(day, dict):
-            continue
-        date = ccusage_day(day)
-        if not date:
-            continue
-        timestamp = f"{date}T00:00:00Z"
-        breakdowns = day.get("modelBreakdowns")
-        if isinstance(breakdowns, list) and breakdowns:
-            for breakdown in breakdowns:
-                if not isinstance(breakdown, dict):
-                    continue
-                model = str(breakdown.get("modelName") or "")
-                records.append(
-                    new_record(
-                        source="claude_code",
-                        timestamp=timestamp,
-                        session_id=f"ccusage:{date}:{model}",
-                        model=model,
-                        input_tokens=as_int(breakdown.get("inputTokens")),
-                        output_tokens=as_int(breakdown.get("outputTokens")),
-                        cache_creation_tokens=as_int(breakdown.get("cacheCreationTokens")),
-                        cache_read_tokens=as_int(breakdown.get("cacheReadTokens")),
-                        cost_usd=as_float(breakdown.get("cost")),
-                        source_path="ccusage daily --json",
-                    )
-                )
-        else:
-            records.append(
-                new_record(
-                    source="claude_code",
-                    timestamp=timestamp,
-                    session_id=f"ccusage:{date}",
-                    model=", ".join(str(model) for model in day.get("modelsUsed", []) if model),
-                    input_tokens=as_int(day.get("inputTokens")),
-                    output_tokens=as_int(day.get("outputTokens")),
-                    cache_creation_tokens=as_int(day.get("cacheCreationTokens")),
-                    cache_read_tokens=as_int(day.get("cacheReadTokens")),
-                    total_tokens=as_int(day.get("totalTokens")),
-                    cost_usd=as_float(day.get("totalCost")),
-                    source_path="ccusage daily --json",
-                )
-            )
-    return records
-
-
-def collect_claude(home: Path, cost_source: str = "auto") -> list[dict[str, Any]]:
-    if cost_source != "raw":
-        records = collect_claude_ccusage(home, cost_source)
-        if records:
-            return records
-    return collect_claude_raw(home)
 
 
 def normalize_ccusage_agent(agent: str) -> str:
@@ -427,218 +249,14 @@ def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, An
     return records
 
 
-def collect_pi(home: Path) -> list[dict[str, Any]]:
-    root = home / ".pi" / "agent" / "sessions"
-    if not root.exists():
-        return []
-
-    records: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for path, event in iter_jsonl(root.rglob("*.jsonl")):
-        message = event.get("message")
-        if not isinstance(message, dict) or message.get("role") != "assistant":
-            continue
-        usage = message.get("usage")
-        if not isinstance(usage, dict):
-            continue
-        record_id = str(event.get("id") or message.get("responseId") or f"{path}:{len(records)}")
-        if record_id in seen:
-            continue
-        seen.add(record_id)
-        cost = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
-        records.append(
-            new_record(
-                source="pi",
-                timestamp=normalize_timestamp(event.get("timestamp") or message.get("timestamp")),
-                session_id=path.stem.split("_", 1)[-1],
-                project=project_from_path(path, "sessions"),
-                provider=str(message.get("provider") or message.get("api") or ""),
-                model=str(message.get("model") or ""),
-                input_tokens=as_int(usage.get("input") or usage.get("input_tokens")),
-                output_tokens=as_int(usage.get("output") or usage.get("output_tokens")),
-                cache_creation_tokens=as_int(usage.get("cacheWrite") or usage.get("cache_creation_input_tokens")),
-                cache_read_tokens=as_int(usage.get("cacheRead") or usage.get("cache_read_input_tokens")),
-                reasoning_tokens=as_int(usage.get("reasoning") or usage.get("reasoning_tokens")),
-                total_tokens=as_int(usage.get("totalTokens") or usage.get("total_tokens")),
-                cost_usd=as_float(cost.get("total") if isinstance(cost, dict) else 0),
-                source_path=rel_home(path),
-            )
-        )
-    return records
-
-
-def codex_session_id(path: Path) -> str:
-    match = re.search(r"rollout-[^-]+-[^-]+-(.+)\.jsonl$", path.name)
-    return match.group(1) if match else path.stem
-
-
-def collect_codex(home: Path) -> list[dict[str, Any]]:
-    roots = [home / ".codex" / "sessions", home / ".codex" / "archived_sessions"]
-    records: list[dict[str, Any]] = []
-
-    for root in roots:
-        if not root.exists():
-            continue
-        for path in root.rglob("*.jsonl"):
-            latest_usage: dict[str, Any] | None = None
-            latest_ts = ""
-            latest_model = ""
-            plan_type = ""
-            for _, event in iter_jsonl([path]):
-                payload = event.get("payload")
-                if isinstance(payload, dict) and event.get("type") == "turn_context":
-                    latest_model = str(payload.get("model") or latest_model)
-                if not isinstance(payload, dict) or payload.get("type") != "token_count":
-                    continue
-                info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
-                usage = info.get("total_token_usage") if isinstance(info, dict) else None
-                if not isinstance(usage, dict):
-                    continue
-                latest_usage = usage
-                latest_ts = normalize_timestamp(event.get("timestamp"))
-                rate_limits = payload.get("rate_limits")
-                if isinstance(rate_limits, dict):
-                    plan_type = str(rate_limits.get("plan_type") or plan_type)
-            if latest_usage:
-                records.append(
-                    new_record(
-                        source="codex",
-                        timestamp=latest_ts,
-                        session_id=codex_session_id(path),
-                        account=plan_type,
-                        model=latest_model,
-                        input_tokens=as_int(latest_usage.get("input_tokens")),
-                        output_tokens=as_int(latest_usage.get("output_tokens")),
-                        cache_read_tokens=as_int(latest_usage.get("cached_input_tokens")),
-                        reasoning_tokens=as_int(latest_usage.get("reasoning_output_tokens")),
-                        total_tokens=as_int(latest_usage.get("total_tokens")),
-                        source_path=rel_home(path),
-                    )
-                )
-    return records
-
-
-def sqlite_copy(path: Path) -> Path | None:
-    if not path.exists():
-        return None
-    temp = tempfile.NamedTemporaryFile(prefix="ai-usage-sqlite-", suffix=".db", delete=False)
-    temp.close()
-    temp_path = Path(temp.name)
-    try:
-        source = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
-        dest = sqlite3.connect(temp_path)
-        with dest:
-            source.backup(dest)
-        source.close()
-        dest.close()
-        return temp_path
-    except sqlite3.Error:
-        try:
-            temp_path.unlink()
-        except OSError:
-            pass
-        return None
-
-
-def parse_opencode_model(raw: Any) -> tuple[str, str]:
-    if not raw:
-        return "", ""
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-        except json.JSONDecodeError:
-            return raw, ""
-    elif isinstance(raw, dict):
-        parsed = raw
-    else:
-        return str(raw), ""
-    return str(parsed.get("id") or ""), str(parsed.get("providerID") or parsed.get("provider") or "")
-
-
-def collect_opencode(home: Path) -> list[dict[str, Any]]:
-    db_path = home / ".local" / "share" / "opencode" / "opencode.db"
-    copied = sqlite_copy(db_path)
-    if copied is None:
-        return []
-
-    records: list[dict[str, Any]] = []
-    try:
-        conn = sqlite3.connect(copied)
-        conn.row_factory = sqlite3.Row
-        query = """
-            SELECT id, directory, title, agent, model, cost,
-                   tokens_input, tokens_output, tokens_reasoning,
-                   tokens_cache_read, tokens_cache_write, time_created
-            FROM session
-        """
-        for row in conn.execute(query):
-            model, provider = parse_opencode_model(row["model"])
-            records.append(
-                new_record(
-                    source="opencode",
-                    timestamp=normalize_timestamp(row["time_created"]),
-                    session_id=str(row["id"] or ""),
-                    project=str(row["directory"] or row["title"] or ""),
-                    provider=provider,
-                    model=model,
-                    input_tokens=as_int(row["tokens_input"]),
-                    output_tokens=as_int(row["tokens_output"]),
-                    cache_creation_tokens=as_int(row["tokens_cache_write"]),
-                    cache_read_tokens=as_int(row["tokens_cache_read"]),
-                    reasoning_tokens=as_int(row["tokens_reasoning"]),
-                    cost_usd=as_float(row["cost"]),
-                    source_path=rel_home(db_path),
-                )
-            )
-        conn.close()
-    except sqlite3.Error as exc:
-        eprint(f"Warning: failed to read opencode database: {exc}")
-    finally:
-        try:
-            copied.unlink()
-        except OSError:
-            pass
-    return records
-
-
-def collect_local(
-    host_label: str = "", claude_cost_source: str = "auto", usage_source: str = "ccusage"
-) -> dict[str, Any]:
+def collect_local(host_label: str = "", ccusage_runner: str = "auto") -> dict[str, Any]:
     home = Path.home()
     label = host_label or socket.gethostname().split(".", 1)[0]
-    records = []
-
-    if usage_source in {"ccusage", "auto"}:
-        try:
-            records = collect_ccusage_unified(home, claude_cost_source)
-        except Exception as exc:  # noqa: BLE001 - ccusage failure should fall through to local parsers.
-            eprint(f"Warning: collect_ccusage_unified failed: {exc}")
-        if records or usage_source == "ccusage":
-            records.sort(key=lambda item: (item.get("timestamp") or "", item.get("source") or "", item.get("session_id") or ""))
-            return {
-                "schema_version": SCHEMA_VERSION,
-                "host": label,
-                "collected_at": utc_now(),
-                "platform": {
-                    "hostname": socket.gethostname(),
-                    "system": platform.system(),
-                    "release": platform.release(),
-                },
-                "records": records,
-                "summary": summarize_records(records),
-            }
-
-    collectors = (
-        ("collect_claude", lambda: collect_claude(home, claude_cost_source)),
-        ("collect_pi", lambda: collect_pi(home)),
-        ("collect_codex", lambda: collect_codex(home)),
-        ("collect_opencode", lambda: collect_opencode(home)),
-    )
-    for collector_name, collector in collectors:
-        try:
-            records.extend(collector())
-        except Exception as exc:  # noqa: BLE001 - collectors should not block other sources.
-            eprint(f"Warning: {collector_name} failed: {exc}")
+    records: list[dict[str, Any]] = []
+    try:
+        records = collect_ccusage_unified(home, ccusage_runner)
+    except Exception as exc:  # noqa: BLE001 - one host should not block cached/offline behavior elsewhere.
+        eprint(f"Warning: collect_ccusage_unified failed: {exc}")
 
     records.sort(key=lambda item: (item.get("timestamp") or "", item.get("source") or "", item.get("session_id") or ""))
     return {
@@ -739,7 +357,7 @@ def parse_host_arg(value: str) -> HostSpec:
 
 
 def run_remote_collect(
-    spec: HostSpec, timeout: int, claude_cost_source: str, usage_source: str
+    spec: HostSpec, timeout: int, ccusage_runner: str
 ) -> tuple[dict[str, Any] | None, str]:
     script = Path(__file__).read_text(encoding="utf-8")
     command = [
@@ -754,10 +372,8 @@ def run_remote_collect(
         "--collect-local",
         "--host-label",
         spec.label,
-        "--claude-cost-source",
-        claude_cost_source,
-        "--usage-source",
-        usage_source,
+        "--ccusage-runner",
+        ccusage_runner,
     ]
     try:
         completed = subprocess.run(
@@ -781,7 +397,7 @@ def run_remote_collect(
 
 
 def collect_host(
-    spec: HostSpec, cache_dir: Path, timeout: int, claude_cost_source: str, usage_source: str
+    spec: HostSpec, cache_dir: Path, timeout: int, ccusage_runner: str
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     path = cache_path(cache_dir, spec.label)
     status = {
@@ -793,12 +409,12 @@ def collect_host(
     }
 
     if spec.is_local:
-        payload = collect_local(spec.label, claude_cost_source, usage_source)
+        payload = collect_local(spec.label, ccusage_runner)
         status["status"] = "updated"
         atomic_write_json(path, payload)
         return payload, status
 
-    payload, error = run_remote_collect(spec, timeout, claude_cost_source, usage_source)
+    payload, error = run_remote_collect(spec, timeout, ccusage_runner)
     if payload is not None:
         status["status"] = "updated"
         atomic_write_json(path, payload)
@@ -879,7 +495,8 @@ def aggregate_daily(
         )
         bucket["records"] += 1
         if record.get("session_id"):
-            bucket["sessions"].add(str(record.get("session_id")))
+            session_host = str(record.get("host") or record.get("host_label") or "")
+            bucket["sessions"].add(f"{session_host}:{record.get('session_id')}")
         if record.get("host"):
             bucket["hosts"].add(str(record.get("host")))
         account_bits = [str(record.get("account_label") or ""), str(record.get("account") or "")]
@@ -1126,7 +743,8 @@ def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> 
                 "service": str(record.get("service") or ""),
                 "provider": str(record.get("provider") or ""),
                 "model": str(record.get("model") or ""),
-                "hosts": str(record.get("hosts") or ""),
+                "host": str(record.get("host") or ""),
+                "hosts": str(record.get("hosts") or record.get("host") or ""),
                 "accounts": str(record.get("accounts") or ""),
                 "records": as_int(record.get("records")),
                 "sessions": as_int(record.get("sessions")),
@@ -1136,7 +754,7 @@ def dashboard_payload(combined: dict[str, Any], daily: list[dict[str, Any]]) -> 
                 "cache_read_tokens": as_int(record.get("cache_read_tokens")),
                 "reasoning_tokens": as_int(record.get("reasoning_tokens")),
                 "total_tokens": as_int(record.get("total_tokens")),
-                "cost_usd": round(as_float(record.get("cost_usd")), 6),
+                "cost_usd": round(as_float(record.get("cost_usd")), 10),
             }
         )
 
@@ -1195,9 +813,10 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .value { font: 29px/.95 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; letter-spacing: -.05em; white-space: nowrap; }
 .rangebar { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 16px 0; border-bottom: 1px solid var(--rule); }
 .presets { display: flex; flex-wrap: wrap; gap: 8px; }
-.rangebar button, .rangebar input { color: var(--ink); background: transparent; border: 1px solid var(--rule); padding: 8px 10px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.rangebar button, .rangebar input, .rangebar select { color: var(--ink); background: var(--paper); border: 1px solid var(--rule); padding: 8px 10px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.rangebar select { min-width: 180px; max-height: 120px; }
 .rangebar button { cursor: pointer; text-transform: uppercase; letter-spacing: .08em; }
-.rangebar button.active, .rangebar button:hover, .rangebar input:focus { border-color: var(--gold); outline: 0; }
+.rangebar button.active, .rangebar button:hover, .rangebar input:focus, .rangebar select:focus { border-color: var(--gold); outline: 0; }
 .custom-range { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .range-readout { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin-left: 6px; }
 .grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 28px; margin-top: 30px; }
@@ -1207,9 +826,26 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .day { flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
 .day:hover { outline: 1px solid var(--gold); outline-offset: 2px; opacity: 1; }
 .seg.in { background: var(--in); } .seg.out { background: var(--out); } .seg.cw { background: var(--cw); } .seg.cr { background: var(--cr); } .seg.rz { background: var(--rz); }
+.chart-axis { position: relative; height: 18px; margin-top: 6px; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.axis-tick { position: absolute; transform: translateX(-50%); white-space: nowrap; }
 .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 10px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .swatch { display: inline-block; width: 10px; height: 10px; margin-right: 5px; vertical-align: -1px; }
 .costline { width: 100%; height: 74px; margin-top: 8px; overflow: visible; }
+.heatmaps { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; margin-top: 30px; }
+.heatmap-wrap { border-top: 1px solid var(--rule); padding-top: 12px; min-width: 0; }
+.heatmap-head { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; margin-bottom: 10px; }
+.heatmap-title { font-size: 18px; letter-spacing: -.02em; }
+.heatmap-max { color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.heatmap-scroll { overflow-x: auto; padding-bottom: 4px; }
+.heat-months { display: grid; gap: 3px; margin: 0 0 5px; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; min-height: 12px; }
+.heat-month { width: 11px; white-space: nowrap; overflow: visible; }
+.heatmap { display: grid; grid-template-rows: repeat(7, 11px); grid-auto-flow: column; grid-auto-columns: 11px; gap: 3px; min-height: 95px; align-items: center; }
+.cell { width: 11px; height: 11px; border: 1px solid rgba(237,228,209,.07); background: #211e18; }
+.cell.empty { opacity: 0; border-color: transparent; }
+.cell.l1 { background: #2f3f39; } .cell.l2 { background: #476a5c; } .cell.l3 { background: #6da077; } .cell.l4 { background: #b5cf73; }
+.cell.cost.l1 { background: #46351d; } .cell.cost.l2 { background: #765426; } .cell.cost.l3 { background: #ad7830; } .cell.cost.l4 { background: var(--gold); }
+.heatmap-legend { display: flex; justify-content: flex-end; align-items: center; gap: 5px; color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin-top: 8px; }
+.hovercard { position: fixed; z-index: 20; pointer-events: none; transform: translate(12px, 12px); border: 1px solid var(--rule-strong); background: #211d16; color: var(--ink); padding: 8px 10px; font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; box-shadow: 0 10px 30px rgba(0,0,0,.35); display: none; max-width: 280px; }
 .servicebar { display: flex; height: 32px; border: 1px solid var(--rule); margin-bottom: 12px; }
 .servicebit { min-width: 2px; }
 .service-list { display: grid; gap: 8px; }
@@ -1229,7 +865,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
 .host { border: 1px solid var(--rule); padding: 7px 9px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--muted); }
 .host.updated .dot { color: var(--green); } .host.cached .dot { color: var(--gold); } .host.missing .dot { color: var(--red); }
 .note { color: var(--muted); font-size: 13px; line-height: 1.45; margin-top: 12px; }
-@media (max-width: 900px) { .mast, .grid, .rangebar { display: block; } .custom-range { margin-top: 12px; } .generated { text-align: left; margin-top: 14px; } .stats { grid-template-columns: repeat(2, 1fr); } .stat:nth-child(2n) { border-right: 0; } }
+@media (max-width: 900px) { .mast, .grid, .rangebar, .heatmaps { display: block; } .heatmap-wrap { margin-top: 20px; } .custom-range { margin-top: 12px; } .generated { text-align: left; margin-top: 14px; } .stats { grid-template-columns: repeat(2, 1fr); } .stat:nth-child(2n) { border-right: 0; } }
 </style>
 </head>
 <body>
@@ -1250,6 +886,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
     <div class="custom-range">
       <span class="label">From</span><input id="fromDate" type="date">
       <span class="label">To</span><input id="toDate" type="date">
+      <span class="label">Hosts</span><select id="hostFilter" multiple size="4"><option value="all" selected>All hosts</option></select>
       <span class="range-readout" id="rangeReadout"></span>
     </div>
   </section>
@@ -1257,6 +894,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
     <div class="panel">
       <h2>Daily Token Flow</h2>
       <div id="chart" class="chart" aria-label="Daily token bars"></div>
+      <div id="chartAxis" class="chart-axis" aria-label="Daily token date axis"></div>
       <div class="legend">
         <span><i class="swatch" style="background:var(--in)"></i>input</span>
         <span><i class="swatch" style="background:var(--out)"></i>output</span>
@@ -1278,6 +916,18 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
       <p class="note">The service field is inferred from provider/model names, so Grok used through pi is counted as Grok while retaining source=pi.</p>
     </aside>
   </section>
+  <section class="heatmaps" aria-label="Daily heatmaps">
+    <div class="heatmap-wrap">
+      <div class="heatmap-head"><div class="heatmap-title">Daily Token Measure</div><div id="tokenHeatMax" class="heatmap-max"></div></div>
+      <div class="heatmap-scroll"><div id="tokenHeatMonths" class="heat-months"></div><div id="tokenHeatmap" class="heatmap"></div></div>
+      <div class="heatmap-legend"><span>less</span><i class="cell"></i><i class="cell l1"></i><i class="cell l2"></i><i class="cell l3"></i><i class="cell l4"></i><span>more</span></div>
+    </div>
+    <div class="heatmap-wrap">
+      <div class="heatmap-head"><div class="heatmap-title">Daily Cost Measure</div><div id="costHeatMax" class="heatmap-max"></div></div>
+      <div class="heatmap-scroll"><div id="costHeatMonths" class="heat-months"></div><div id="costHeatmap" class="heatmap"></div></div>
+      <div class="heatmap-legend"><span>less</span><i class="cell cost"></i><i class="cell cost l1"></i><i class="cell cost l2"></i><i class="cell cost l3"></i><i class="cell cost l4"></i><span>more</span></div>
+    </div>
+  </section>
   <section class="panel" style="margin-top:30px">
     <h2>Top Models</h2>
     <table>
@@ -1290,12 +940,13 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
     <div id="hosts" class="hosts"></div>
   </section>
 </main>
+<div id="hovercard" class="hovercard"></div>
 <script id="usage-data" type="application/json">__DATA__</script>
 <script>
 const D = JSON.parse(document.getElementById('usage-data').textContent);
 const fields = ['input_tokens','output_tokens','cache_creation_tokens','cache_read_tokens','reasoning_tokens'];
 const segClass = ['in','out','cw','cr','rz'];
-let state = { from: null, to: null, preset: 'all' };
+let state = { from: null, to: null, preset: 'all', hosts: ['all'] };
 function fmt(n) { n = Number(n || 0); if (n >= 1e9) return (n/1e9).toFixed(1)+'B'; if (n >= 1e6) return (n/1e6).toFixed(1)+'M'; if (n >= 1e3) return (n/1e3).toFixed(0)+'k'; return String(Math.round(n)); }
 function usd(n) { return '$' + Number(n || 0).toFixed(2); }
 function pct(n) { return Number(n || 0).toFixed(1) + '%'; }
@@ -1304,7 +955,11 @@ function clear(id) { const el = document.getElementById(id); while (el.firstChil
 function addTotals(target, row) { fields.concat(['total_tokens']).forEach(f => target[f] = Number(target[f] || 0) + Number(row[f] || 0)); target.cost_usd = Number(target.cost_usd || 0) + Number(row.cost_usd || 0); target.records = Number(target.records || 0) + Number(row.records || 0); target.sessions = Number(target.sessions || 0) + Number(row.sessions || 0); }
 function dateAdd(date, delta) { const d = new Date(date + 'T00:00:00Z'); d.setUTCDate(d.getUTCDate() + delta); return d.toISOString().slice(0,10); }
 function availableDates() { return [...new Set((D.rows || []).map(r => r.date).filter(Boolean))].sort(); }
-function selectedRows() { return (D.rows || []).filter(r => (!state.from || r.date >= state.from) && (!state.to || r.date <= state.to)); }
+function rowHosts(row) { return (row.host || row.hosts || '').split(',').map(v => v.trim()).filter(Boolean); }
+function selectedRows() { return (D.rows || []).filter(r => {
+  const hostOk = state.hosts.includes('all') || state.hosts.length === 0 || rowHosts(r).some(host => state.hosts.includes(host));
+  return (!state.from || r.date >= state.from) && (!state.to || r.date <= state.to) && hostOk;
+}); }
 function derive(rows) {
   const daysMap = new Map(), modelsMap = new Map(), servicesMap = new Map();
   rows.forEach(row => {
@@ -1335,6 +990,24 @@ function renderStats(summary) {
   const root = clear('stats');
   stats.forEach(([label, value]) => { const box = node('div','stat'); box.append(node('div','label',label)); box.append(node('div','value',value)); root.append(box); });
 }
+function dateLabel(date) {
+  const parsed = new Date(date + 'T00:00:00Z');
+  return parsed.toLocaleDateString('en', {month: 'short', day: 'numeric', timeZone: 'UTC'});
+}
+function renderChartAxis(days) {
+  const axis = clear('chartAxis');
+  if (!days.length) return;
+  const count = Math.min(7, days.length);
+  const used = new Set();
+  for (let i = 0; i < count; i += 1) {
+    const index = count === 1 ? 0 : Math.round(i * (days.length - 1) / (count - 1));
+    if (used.has(index)) continue;
+    used.add(index);
+    const tick = node('span', 'axis-tick', dateLabel(days[index].date));
+    tick.style.left = days.length === 1 ? '0%' : `${index / (days.length - 1) * 100}%`;
+    axis.append(tick);
+  }
+}
 function renderChart(days) {
   const root = clear('chart');
   const max = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
@@ -1344,6 +1017,7 @@ function renderChart(days) {
     fields.forEach((f, idx) => { const seg = node('div', 'seg ' + segClass[idx]); const height = Math.max(0, Number(d[f] || 0) / max * 100); seg.style.height = height ? Math.max(.8, height) + '%' : '0'; day.append(seg); });
     root.append(day);
   });
+  renderChartAxis(days);
 }
 function renderCost(days) {
   const svg = clear('costline');
@@ -1376,6 +1050,77 @@ function renderTokenmax(days, summary) {
   const line = document.getElementById('tokenmaxLine');
   line.textContent = summary.total_tokens ? `You are tokenmaxxing at ${fmt(avg)} tokens/day in this range, with ${fmt(cache)} cache tokens doing the heavy lifting.` : 'No tokens in this range.';
 }
+function heatLevel(value, max) { if (!value || !max) return 0; const ratio = value / max; if (ratio >= .75) return 4; if (ratio >= .45) return 3; if (ratio >= .18) return 2; return 1; }
+function calendarDays(days) {
+  if (!state.from || !state.to) return days.map(d => d.date);
+  const output = [];
+  let cursor = state.from;
+  while (cursor <= state.to && output.length < 3700) { output.push(cursor); cursor = dateAdd(cursor, 1); }
+  return output;
+}
+function shortMonth(date) { return new Date(date + 'T00:00:00Z').toLocaleString('en', {month: 'short', timeZone: 'UTC'}); }
+function showHover(event, lines) {
+  const tip = document.getElementById('hovercard');
+  tip.replaceChildren(...lines.map(line => node('div', '', line)));
+  tip.style.left = event.clientX + 'px';
+  tip.style.top = event.clientY + 'px';
+  tip.style.display = 'block';
+}
+function moveHover(event) {
+  const tip = document.getElementById('hovercard');
+  tip.style.left = event.clientX + 'px';
+  tip.style.top = event.clientY + 'px';
+}
+function hideHover() { document.getElementById('hovercard').style.display = 'none'; }
+function renderMonthMarkers(monthsId, calendar) {
+  const root = clear(monthsId);
+  if (!calendar.length) return;
+  const firstDow = new Date(calendar[0] + 'T00:00:00Z').getUTCDay();
+  const weekCount = Math.ceil((firstDow + calendar.length) / 7);
+  root.style.gridTemplateColumns = `repeat(${weekCount}, 11px)`;
+  const labels = Array.from({length: weekCount}, () => '');
+  calendar.forEach((date, index) => {
+    const week = Math.floor((firstDow + index) / 7);
+    if (index === 0 || date.endsWith('-01')) labels[week] = shortMonth(date);
+  });
+  labels.forEach(label => root.append(node('span', 'heat-month', label)));
+}
+function renderHeatmap(rootId, monthsId, maxId, days, field, formatter, costMode) {
+  const root = clear(rootId);
+  const byDate = new Map(days.map(day => [day.date, day]));
+  const calendar = calendarDays(days);
+  renderMonthMarkers(monthsId, calendar);
+  const max = Math.max(0, ...calendar.map(date => Number((byDate.get(date) || {})[field] || 0)));
+  document.getElementById(maxId).textContent = max ? `peak ${formatter(max)}` : 'no activity';
+  if (calendar.length) {
+    const firstDow = new Date(calendar[0] + 'T00:00:00Z').getUTCDay();
+    for (let i = 0; i < firstDow; i += 1) root.append(node('i', 'cell empty'));
+  }
+  calendar.forEach(date => {
+    const day = byDate.get(date) || {date, total_tokens: 0, cost_usd: 0, input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, reasoning_tokens: 0};
+    const value = Number(day[field] || 0);
+    const level = heatLevel(value, max);
+    const cell = node('i', `cell${costMode ? ' cost' : ''}${level ? ' l' + level : ''}`);
+    const lines = costMode
+      ? [date, `${formatter(value)} reported cost`, `${fmt(day.total_tokens || 0)} tokens`]
+      : [date, `${formatter(value)} total tokens`, `${fmt(day.input_tokens || 0)} in · ${fmt(day.output_tokens || 0)} out`, `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache · ${usd(day.cost_usd || 0)}`];
+    cell.setAttribute('aria-label', lines.join(' · '));
+    cell.addEventListener('mouseenter', event => showHover(event, lines));
+    cell.addEventListener('mousemove', moveHover);
+    cell.addEventListener('mouseleave', hideHover);
+    root.append(cell);
+  });
+}
+function renderHeatmaps(days) {
+  renderHeatmap('tokenHeatmap', 'tokenHeatMonths', 'tokenHeatMax', days, 'total_tokens', fmt, false);
+  renderHeatmap('costHeatmap', 'costHeatMonths', 'costHeatMax', days, 'cost_usd', usd, true);
+}
+function hostSummary(hosts) {
+  const list = (hosts || []).filter(Boolean);
+  if (!list.length) return 'all hosts';
+  if (list.length <= 3) return list.join(', ');
+  return `${list.slice(0, 3).join(', ')} +${list.length - 3}`;
+}
 function renderModels(models) {
   const body = clear('models');
   models.slice(0, 30).forEach(row => {
@@ -1383,7 +1128,7 @@ function renderModels(models) {
     const name = document.createElement('td');
     name.title = `sources: ${(row.sources || []).join(', ')}; hosts: ${(row.hosts || []).join(', ')}; accounts: ${(row.accounts || []).join(', ')}`;
     name.append(node('div','model-name',row.model || 'unknown'));
-    name.append(node('div','meta',`${row.service || 'unknown'} ${row.provider ? '· '+row.provider : ''} · ${(row.hosts || []).length || 'all'} hosts`));
+    name.append(node('div','meta',`${row.service || 'unknown'} ${row.provider ? '· '+row.provider : ''} · ${hostSummary(row.hosts)}`));
     tr.append(name);
     [['days',fmt(row.days)],['input',fmt(row.input_tokens)],['output',fmt(row.output_tokens)],['cache',fmt(Number(row.cache_creation_tokens || 0)+Number(row.cache_read_tokens || 0))],['total',fmt(row.total_tokens)],['cost',usd(row.cost_usd)]].forEach(([, value]) => tr.append(node('td','num',value)));
     body.append(tr);
@@ -1412,15 +1157,34 @@ function applyCustomRange() {
   document.querySelectorAll('#presets button').forEach(b => b.classList.remove('active'));
   renderAll();
 }
+function populateHostFilter() {
+  const select = document.getElementById('hostFilter');
+  const hosts = [...new Set((D.rows || []).flatMap(rowHosts))].sort();
+  hosts.forEach(host => select.append(node('option', '', host)));
+}
+function applyHostFilter() {
+  const select = document.getElementById('hostFilter');
+  const values = [...select.selectedOptions].map(option => option.value);
+  if (values.includes('all') || values.length === 0) {
+    state.hosts = ['all'];
+    [...select.options].forEach(option => option.selected = option.value === 'all');
+  } else {
+    state.hosts = values;
+  }
+  renderAll();
+}
 function renderAll() {
   const derived = derive(selectedRows());
-  renderStats(derived.summary); renderChart(derived.days); renderCost(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderModels(derived.models); renderHosts();
+  renderStats(derived.summary); renderChart(derived.days); renderCost(derived.days); renderServices(derived.services); renderTokenmax(derived.days, derived.summary); renderHeatmaps(derived.days); renderModels(derived.models); renderHosts();
   const readout = document.getElementById('rangeReadout');
-  readout.textContent = `${derived.days.length} days · ${derived.summary.first_date || 'n/a'} to ${derived.summary.latest_date || 'n/a'}`;
+  const hostText = state.hosts.includes('all') ? 'all hosts' : state.hosts.join(', ');
+  readout.textContent = `${derived.days.length} days · ${derived.summary.first_date || 'n/a'} to ${derived.summary.latest_date || 'n/a'} · ${hostText}`;
 }
 document.querySelectorAll('#presets button').forEach(button => button.addEventListener('click', () => applyRange(button.dataset.range)));
 document.getElementById('fromDate').addEventListener('change', applyCustomRange);
 document.getElementById('toDate').addEventListener('change', applyCustomRange);
+document.getElementById('hostFilter').addEventListener('change', applyHostFilter);
+populateHostFilter();
 applyRange('all');
 </script>
 </body>
@@ -1429,7 +1193,8 @@ applyRange('all');
 
 
 def write_html(path: Path, combined: dict[str, Any], daily: list[dict[str, Any]]) -> None:
-    payload = dashboard_payload(combined, daily)
+    dashboard_daily = aggregate_daily(combined["records"], split_hosts=True, split_accounts=False)
+    payload = dashboard_payload(combined, dashboard_daily or daily)
     rendered = HTML_TEMPLATE.replace("__DATA__", json_for_script(payload))
     rendered = rendered.replace("AI Usage Ledger", html_escape("AI Usage Ledger"), 1)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1477,16 +1242,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--daily-split-accounts", action="store_true", help="Keep accounts separate in daily aggregates instead of merging them.")
     parser.add_argument("--ssh-timeout", type=int, default=8, help="SSH connect timeout in seconds.")
     parser.add_argument(
-        "--claude-cost-source",
-        choices=("auto", "raw", "ccusage", "npx"),
+        "--ccusage-runner",
+        choices=("auto", "ccusage", "npx"),
         default="auto",
-        help="ccusage runner: auto uses installed ccusage or npx ccusage@latest, raw uses local parsers only.",
-    )
-    parser.add_argument(
-        "--usage-source",
-        choices=("ccusage", "auto", "local"),
-        default="ccusage",
-        help="Primary usage collector. ccusage uses unified ccusage data; auto falls back to local parsers; local skips ccusage.",
+        help="ccusage runner: auto uses npx ccusage@latest or installed ccusage.",
     )
     parser.add_argument("--json-only", action="store_true", help="Do not write CSV output.")
     parser.add_argument("--collect-local", action="store_true", help=argparse.SUPPRESS)
@@ -1497,7 +1256,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     if args.collect_local:
-        print(json.dumps(collect_local(args.host_label, args.claude_cost_source, args.usage_source), sort_keys=True))
+        print(json.dumps(collect_local(args.host_label, args.ccusage_runner), sort_keys=True))
         return 0
 
     specs = default_specs(not args.no_local)
@@ -1517,7 +1276,7 @@ def main() -> int:
     host_payloads: list[tuple[HostSpec, dict[str, Any], bool]] = []
     statuses: list[dict[str, Any]] = []
     for spec in specs:
-        payload, status = collect_host(spec, args.cache_dir, args.ssh_timeout, args.claude_cost_source, args.usage_source)
+        payload, status = collect_host(spec, args.cache_dir, args.ssh_timeout, args.ccusage_runner)
         statuses.append(status)
         if payload is None:
             eprint(f"{spec.label}: no data ({status.get('message')})")

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -1,0 +1,978 @@
+#!/usr/bin/env python3
+"""Collect local and remote AI coding-agent usage into JSON and CSV.
+
+The collector intentionally records usage metadata only. It does not copy prompts,
+responses, tool arguments, auth files, or raw transcripts into the output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import glob
+import json
+import os
+import platform
+import re
+import shlex
+import shutil
+import socket
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+DEFAULT_CACHE_DIR = ".ai-usage-cache"
+DEFAULT_JSON = "ai-usage.json"
+DEFAULT_CSV = "ai-usage.csv"
+DEFAULT_DAILY_JSON = "ai-usage-daily.json"
+DEFAULT_DAILY_CSV = "ai-usage-daily.csv"
+
+
+@dataclass
+class HostSpec:
+    label: str
+    target: str = "local"
+    account_label: str = ""
+    options: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_local(self) -> bool:
+        return self.target in {"", "local", "localhost", "127.0.0.1", "::1"}
+
+
+def eprint(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def iso_date(timestamp: str) -> str:
+    if not timestamp:
+        return ""
+    return timestamp[:10]
+
+
+def normalize_timestamp(value: Any) -> str:
+    if value is None or value == "":
+        return ""
+    if isinstance(value, (int, float)):
+        seconds = float(value)
+        if seconds > 10_000_000_000:
+            seconds = seconds / 1000.0
+        try:
+            return dt.datetime.fromtimestamp(seconds, dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+        except (OSError, OverflowError, ValueError):
+            return ""
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return ""
+        if text.isdigit():
+            return normalize_timestamp(int(text))
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = dt.datetime.fromisoformat(text)
+        except ValueError:
+            return value.strip()
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.astimezone(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    return ""
+
+
+def as_int(value: Any) -> int:
+    if value is None or value == "":
+        return 0
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def as_float(value: Any) -> float:
+    if value is None or value == "":
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def get_nested(mapping: dict[str, Any], *keys: str) -> Any:
+    current: Any = mapping
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def rel_home(path: Path) -> str:
+    try:
+        return "~/" + str(path.expanduser().resolve().relative_to(Path.home().resolve()))
+    except ValueError:
+        return str(path)
+
+
+def project_from_path(path: Path, marker: str) -> str:
+    parts = path.parts
+    try:
+        idx = parts.index(marker)
+    except ValueError:
+        return ""
+    if idx + 1 < len(parts):
+        return parts[idx + 1]
+    return ""
+
+
+def infer_service(source: str, provider: str, model: str) -> str:
+    haystack = f"{source} {provider} {model}".lower()
+    if "grok" in haystack or "xai" in haystack or "x.ai" in haystack:
+        return "grok"
+    if "claude" in haystack or "anthropic" in haystack:
+        return "claude"
+    if "codex" in haystack:
+        return "codex"
+    if "openai" in haystack or model.startswith("gpt-") or model.startswith("o"):
+        return "openai"
+    return source
+
+
+def new_record(
+    *,
+    source: str,
+    timestamp: str,
+    session_id: str = "",
+    project: str = "",
+    account: str = "",
+    provider: str = "",
+    model: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    reasoning_tokens: int = 0,
+    total_tokens: int = 0,
+    cost_usd: float = 0.0,
+    source_path: str = "",
+) -> dict[str, Any]:
+    if not total_tokens:
+        total_tokens = input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens
+    service = infer_service(source, provider, model)
+    return {
+        "date": iso_date(timestamp),
+        "timestamp": timestamp,
+        "source": source,
+        "service": service,
+        "account": account,
+        "provider": provider,
+        "model": model,
+        "session_id": session_id,
+        "project": project,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_creation_tokens": cache_creation_tokens,
+        "cache_read_tokens": cache_read_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "total_tokens": total_tokens,
+        "cost_usd": round(cost_usd, 10),
+        "source_path": source_path,
+    }
+
+
+def iter_jsonl(paths: Iterable[Path]) -> Iterable[tuple[Path, dict[str, Any]]]:
+    for path in paths:
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    if not line.strip():
+                        continue
+                    try:
+                        value = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(value, dict):
+                        yield path, value
+        except OSError:
+            continue
+
+
+def collect_claude_raw(home: Path) -> list[dict[str, Any]]:
+    roots = [home / ".claude" / "projects", home / ".claude" / "transcripts"]
+    paths: list[Path] = []
+    for root in roots:
+        if root.exists():
+            paths.extend(root.rglob("*.jsonl"))
+
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for path, event in iter_jsonl(paths):
+        message = event.get("message")
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        record_id = str(event.get("uuid") or event.get("requestId") or message.get("id") or f"{path}:{len(records)}")
+        if record_id in seen:
+            continue
+        seen.add(record_id)
+        records.append(
+            new_record(
+                source="claude_code",
+                timestamp=normalize_timestamp(event.get("timestamp")),
+                session_id=str(event.get("sessionId") or path.stem),
+                project=project_from_path(path, "projects"),
+                model=str(message.get("model") or ""),
+                input_tokens=as_int(usage.get("input_tokens")),
+                output_tokens=as_int(usage.get("output_tokens")),
+                cache_creation_tokens=as_int(usage.get("cache_creation_input_tokens")),
+                cache_read_tokens=as_int(usage.get("cache_read_input_tokens")),
+                source_path=rel_home(path),
+            )
+        )
+    return records
+
+
+def run_ccusage(mode: str, home: Path) -> dict[str, Any] | None:
+    if mode == "raw":
+        return None
+    command: list[str] | None = None
+    if mode in {"auto", "ccusage"} and shutil.which("ccusage"):
+        command = ["ccusage", "daily", "--json"]
+    elif mode in {"auto", "npx"} and shutil.which("npx"):
+        command = ["npx", "--yes", "ccusage@latest", "daily", "--json"]
+    if command is None:
+        return None
+
+    env = os.environ.copy()
+    env.setdefault("HOME", str(home))
+    try:
+        completed = subprocess.run(
+            command,
+            text=True,
+            capture_output=True,
+            timeout=90,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        eprint(f"Warning: ccusage failed: {exc}")
+        return None
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip().splitlines()
+        detail = stderr[-1] if stderr else f"exit {completed.returncode}"
+        eprint(f"Warning: ccusage failed: {detail}")
+        return None
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        eprint(f"Warning: ccusage returned invalid JSON: {exc}")
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def collect_claude_ccusage(home: Path, mode: str) -> list[dict[str, Any]]:
+    payload = run_ccusage(mode, home)
+    if payload is None:
+        return []
+    daily = payload.get("daily")
+    if not isinstance(daily, list):
+        return []
+
+    records: list[dict[str, Any]] = []
+    for day in daily:
+        if not isinstance(day, dict):
+            continue
+        date = str(day.get("date") or "")
+        if not date:
+            continue
+        timestamp = f"{date}T00:00:00Z"
+        breakdowns = day.get("modelBreakdowns")
+        if isinstance(breakdowns, list) and breakdowns:
+            for breakdown in breakdowns:
+                if not isinstance(breakdown, dict):
+                    continue
+                model = str(breakdown.get("modelName") or "")
+                records.append(
+                    new_record(
+                        source="claude_code",
+                        timestamp=timestamp,
+                        session_id=f"ccusage:{date}:{model}",
+                        model=model,
+                        input_tokens=as_int(breakdown.get("inputTokens")),
+                        output_tokens=as_int(breakdown.get("outputTokens")),
+                        cache_creation_tokens=as_int(breakdown.get("cacheCreationTokens")),
+                        cache_read_tokens=as_int(breakdown.get("cacheReadTokens")),
+                        cost_usd=as_float(breakdown.get("cost")),
+                        source_path="ccusage daily --json",
+                    )
+                )
+        else:
+            records.append(
+                new_record(
+                    source="claude_code",
+                    timestamp=timestamp,
+                    session_id=f"ccusage:{date}",
+                    model=", ".join(str(model) for model in day.get("modelsUsed", []) if model),
+                    input_tokens=as_int(day.get("inputTokens")),
+                    output_tokens=as_int(day.get("outputTokens")),
+                    cache_creation_tokens=as_int(day.get("cacheCreationTokens")),
+                    cache_read_tokens=as_int(day.get("cacheReadTokens")),
+                    total_tokens=as_int(day.get("totalTokens")),
+                    cost_usd=as_float(day.get("totalCost")),
+                    source_path="ccusage daily --json",
+                )
+            )
+    return records
+
+
+def collect_claude(home: Path, cost_source: str = "auto") -> list[dict[str, Any]]:
+    if cost_source != "raw":
+        records = collect_claude_ccusage(home, cost_source)
+        if records:
+            return records
+    return collect_claude_raw(home)
+
+
+def collect_pi(home: Path) -> list[dict[str, Any]]:
+    root = home / ".pi" / "agent" / "sessions"
+    if not root.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for path, event in iter_jsonl(root.rglob("*.jsonl")):
+        message = event.get("message")
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        usage = message.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        record_id = str(event.get("id") or message.get("responseId") or f"{path}:{len(records)}")
+        if record_id in seen:
+            continue
+        seen.add(record_id)
+        cost = usage.get("cost") if isinstance(usage.get("cost"), dict) else {}
+        records.append(
+            new_record(
+                source="pi",
+                timestamp=normalize_timestamp(event.get("timestamp") or message.get("timestamp")),
+                session_id=path.stem.split("_", 1)[-1],
+                project=project_from_path(path, "sessions"),
+                provider=str(message.get("provider") or message.get("api") or ""),
+                model=str(message.get("model") or ""),
+                input_tokens=as_int(usage.get("input") or usage.get("input_tokens")),
+                output_tokens=as_int(usage.get("output") or usage.get("output_tokens")),
+                cache_creation_tokens=as_int(usage.get("cacheWrite") or usage.get("cache_creation_input_tokens")),
+                cache_read_tokens=as_int(usage.get("cacheRead") or usage.get("cache_read_input_tokens")),
+                reasoning_tokens=as_int(usage.get("reasoning") or usage.get("reasoning_tokens")),
+                total_tokens=as_int(usage.get("totalTokens") or usage.get("total_tokens")),
+                cost_usd=as_float(cost.get("total") if isinstance(cost, dict) else 0),
+                source_path=rel_home(path),
+            )
+        )
+    return records
+
+
+def codex_session_id(path: Path) -> str:
+    match = re.search(r"rollout-[^-]+-[^-]+-(.+)\.jsonl$", path.name)
+    return match.group(1) if match else path.stem
+
+
+def collect_codex(home: Path) -> list[dict[str, Any]]:
+    roots = [home / ".codex" / "sessions", home / ".codex" / "archived_sessions"]
+    records: list[dict[str, Any]] = []
+
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.jsonl"):
+            latest_usage: dict[str, Any] | None = None
+            latest_ts = ""
+            latest_model = ""
+            plan_type = ""
+            for _, event in iter_jsonl([path]):
+                payload = event.get("payload")
+                if isinstance(payload, dict) and event.get("type") == "turn_context":
+                    latest_model = str(payload.get("model") or latest_model)
+                if not isinstance(payload, dict) or payload.get("type") != "token_count":
+                    continue
+                info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
+                usage = info.get("total_token_usage") if isinstance(info, dict) else None
+                if not isinstance(usage, dict):
+                    continue
+                latest_usage = usage
+                latest_ts = normalize_timestamp(event.get("timestamp"))
+                rate_limits = payload.get("rate_limits")
+                if isinstance(rate_limits, dict):
+                    plan_type = str(rate_limits.get("plan_type") or plan_type)
+            if latest_usage:
+                records.append(
+                    new_record(
+                        source="codex",
+                        timestamp=latest_ts,
+                        session_id=codex_session_id(path),
+                        account=plan_type,
+                        model=latest_model,
+                        input_tokens=as_int(latest_usage.get("input_tokens")),
+                        output_tokens=as_int(latest_usage.get("output_tokens")),
+                        cache_read_tokens=as_int(latest_usage.get("cached_input_tokens")),
+                        reasoning_tokens=as_int(latest_usage.get("reasoning_output_tokens")),
+                        total_tokens=as_int(latest_usage.get("total_tokens")),
+                        source_path=rel_home(path),
+                    )
+                )
+    return records
+
+
+def sqlite_copy(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    temp = tempfile.NamedTemporaryFile(prefix="ai-usage-sqlite-", suffix=".db", delete=False)
+    temp.close()
+    temp_path = Path(temp.name)
+    try:
+        source = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        dest = sqlite3.connect(temp_path)
+        with dest:
+            source.backup(dest)
+        source.close()
+        dest.close()
+        return temp_path
+    except sqlite3.Error:
+        try:
+            temp_path.unlink()
+        except OSError:
+            pass
+        return None
+
+
+def parse_opencode_model(raw: Any) -> tuple[str, str]:
+    if not raw:
+        return "", ""
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return raw, ""
+    elif isinstance(raw, dict):
+        parsed = raw
+    else:
+        return str(raw), ""
+    return str(parsed.get("id") or ""), str(parsed.get("providerID") or parsed.get("provider") or "")
+
+
+def collect_opencode(home: Path) -> list[dict[str, Any]]:
+    db_path = home / ".local" / "share" / "opencode" / "opencode.db"
+    copied = sqlite_copy(db_path)
+    if copied is None:
+        return []
+
+    records: list[dict[str, Any]] = []
+    try:
+        conn = sqlite3.connect(copied)
+        conn.row_factory = sqlite3.Row
+        query = """
+            SELECT id, directory, title, agent, model, cost,
+                   tokens_input, tokens_output, tokens_reasoning,
+                   tokens_cache_read, tokens_cache_write, time_created
+            FROM session
+        """
+        for row in conn.execute(query):
+            model, provider = parse_opencode_model(row["model"])
+            records.append(
+                new_record(
+                    source="opencode",
+                    timestamp=normalize_timestamp(row["time_created"]),
+                    session_id=str(row["id"] or ""),
+                    project=str(row["directory"] or row["title"] or ""),
+                    provider=provider,
+                    model=model,
+                    input_tokens=as_int(row["tokens_input"]),
+                    output_tokens=as_int(row["tokens_output"]),
+                    cache_creation_tokens=as_int(row["tokens_cache_write"]),
+                    cache_read_tokens=as_int(row["tokens_cache_read"]),
+                    reasoning_tokens=as_int(row["tokens_reasoning"]),
+                    cost_usd=as_float(row["cost"]),
+                    source_path=rel_home(db_path),
+                )
+            )
+        conn.close()
+    except sqlite3.Error as exc:
+        eprint(f"Warning: failed to read opencode database: {exc}")
+    finally:
+        try:
+            copied.unlink()
+        except OSError:
+            pass
+    return records
+
+
+def collect_local(host_label: str = "", claude_cost_source: str = "auto") -> dict[str, Any]:
+    home = Path.home()
+    label = host_label or socket.gethostname().split(".", 1)[0]
+    records = []
+    collectors = (
+        ("collect_claude", lambda: collect_claude(home, claude_cost_source)),
+        ("collect_pi", lambda: collect_pi(home)),
+        ("collect_codex", lambda: collect_codex(home)),
+        ("collect_opencode", lambda: collect_opencode(home)),
+    )
+    for collector_name, collector in collectors:
+        try:
+            records.extend(collector())
+        except Exception as exc:  # noqa: BLE001 - collectors should not block other sources.
+            eprint(f"Warning: {collector_name} failed: {exc}")
+
+    records.sort(key=lambda item: (item.get("timestamp") or "", item.get("source") or "", item.get("session_id") or ""))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "host": label,
+        "collected_at": utc_now(),
+        "platform": {
+            "hostname": socket.gethostname(),
+            "system": platform.system(),
+            "release": platform.release(),
+        },
+        "records": records,
+        "summary": summarize_records(records),
+    }
+
+
+def summarize_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    by_source: dict[str, dict[str, Any]] = {}
+    by_service: dict[str, dict[str, Any]] = {}
+    for record in records:
+        source = str(record.get("source") or "unknown")
+        service = str(record.get("service") or source)
+        for groups, key in ((by_source, source), (by_service, service)):
+            bucket = groups.setdefault(key, {"records": 0, "total_tokens": 0, "cost_usd": 0.0})
+            bucket["records"] += 1
+            bucket["total_tokens"] += as_int(record.get("total_tokens"))
+            bucket["cost_usd"] += as_float(record.get("cost_usd"))
+    for groups in (by_source, by_service):
+        for bucket in groups.values():
+            bucket["cost_usd"] = round(bucket["cost_usd"], 6)
+    return {"records": len(records), "by_source": by_source, "by_service": by_service}
+
+
+def safe_label(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", value.strip())
+    return cleaned.strip("._-") or "host"
+
+
+def cache_path(cache_dir: Path, label: str) -> Path:
+    return cache_dir / f"{safe_label(label)}.json"
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def parse_inventory(path: Path) -> list[HostSpec]:
+    specs: list[HostSpec] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise SystemExit(f"Unable to read inventory {path}: {exc}") from exc
+
+    for line_no, raw_line in enumerate(lines, start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(line, comments=True)
+        except ValueError as exc:
+            raise SystemExit(f"Invalid inventory line {line_no}: {exc}") from exc
+        if not parts:
+            continue
+        values: list[str] = []
+        options: dict[str, str] = {}
+        for part in parts:
+            if "=" in part:
+                key, value = part.split("=", 1)
+                options[key] = value
+            else:
+                values.append(part)
+        if len(values) == 1:
+            label = values[0]
+            target = values[0]
+        else:
+            label = values[0]
+            target = values[1]
+        specs.append(HostSpec(label=label, target=target, account_label=options.get("account", ""), options=options))
+    return specs
+
+
+def parse_host_arg(value: str) -> HostSpec:
+    if "=" in value:
+        label, target = value.split("=", 1)
+        return HostSpec(label=label, target=target)
+    return HostSpec(label=value, target=value)
+
+
+def run_remote_collect(spec: HostSpec, timeout: int, claude_cost_source: str) -> tuple[dict[str, Any] | None, str]:
+    script = Path(__file__).read_text(encoding="utf-8")
+    command = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        f"ConnectTimeout={timeout}",
+        spec.target,
+        "python3",
+        "-",
+        "--collect-local",
+        "--host-label",
+        spec.label,
+        "--claude-cost-source",
+        claude_cost_source,
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            input=script,
+            text=True,
+            capture_output=True,
+            timeout=max(timeout + 20, 30),
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return None, str(exc)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip().splitlines()
+        return None, stderr[-1] if stderr else f"ssh exited {completed.returncode}"
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON from host: {exc}"
+    return payload if isinstance(payload, dict) else None, ""
+
+
+def collect_host(
+    spec: HostSpec, cache_dir: Path, timeout: int, claude_cost_source: str
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    path = cache_path(cache_dir, spec.label)
+    status = {
+        "host": spec.label,
+        "target": spec.target,
+        "status": "unknown",
+        "cache": str(path),
+        "message": "",
+    }
+
+    if spec.is_local:
+        payload = collect_local(spec.label, claude_cost_source)
+        status["status"] = "updated"
+        atomic_write_json(path, payload)
+        return payload, status
+
+    payload, error = run_remote_collect(spec, timeout, claude_cost_source)
+    if payload is not None:
+        status["status"] = "updated"
+        atomic_write_json(path, payload)
+        return payload, status
+
+    cached = load_json(path)
+    if cached is not None:
+        status["status"] = "cached"
+        status["message"] = error
+        return cached, status
+
+    status["status"] = "missing"
+    status["message"] = error
+    return None, status
+
+
+def add_host_context(payload: dict[str, Any], spec: HostSpec, cached: bool) -> list[dict[str, Any]]:
+    host = str(payload.get("host") or spec.label)
+    collected_at = str(payload.get("collected_at") or "")
+    records = payload.get("records") if isinstance(payload.get("records"), list) else []
+    output = []
+    for item in records:
+        if not isinstance(item, dict):
+            continue
+        record = dict(item)
+        record["host"] = host
+        record["host_label"] = spec.label
+        record["account_label"] = spec.account_label
+        if spec.account_label and not record.get("account"):
+            record["account"] = spec.account_label
+        record["cache_collected_at"] = collected_at
+        record["from_cache"] = cached
+        output.append(record)
+    return output
+
+
+def aggregate_daily(
+    records: list[dict[str, Any]], *, split_hosts: bool = False, split_accounts: bool = False
+) -> list[dict[str, Any]]:
+    buckets: dict[tuple[str, ...], dict[str, Any]] = {}
+    for record in records:
+        host_value = str(record.get("host") or "") if split_hosts else "all"
+        account_label_value = str(record.get("account_label") or "") if split_accounts else "all"
+        account_value = str(record.get("account") or "") if split_accounts else "all"
+        key = (
+            str(record.get("date") or ""),
+            host_value,
+            account_label_value,
+            str(record.get("source") or ""),
+            str(record.get("service") or ""),
+            str(record.get("provider") or ""),
+            str(record.get("model") or ""),
+            account_value,
+        )
+        bucket = buckets.setdefault(
+            key,
+            {
+                "date": key[0],
+                "host": key[1],
+                "account_label": key[2],
+                "source": key[3],
+                "service": key[4],
+                "provider": key[5],
+                "model": key[6],
+                "account": key[7],
+                "records": 0,
+                "sessions": set(),
+                "hosts": set(),
+                "accounts": set(),
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cache_read_tokens": 0,
+                "reasoning_tokens": 0,
+                "total_tokens": 0,
+                "cost_usd": 0.0,
+            },
+        )
+        bucket["records"] += 1
+        if record.get("session_id"):
+            bucket["sessions"].add(str(record.get("session_id")))
+        if record.get("host"):
+            bucket["hosts"].add(str(record.get("host")))
+        account_bits = [str(record.get("account_label") or ""), str(record.get("account") or "")]
+        account_text = ":".join(bit for bit in account_bits if bit)
+        if account_text:
+            bucket["accounts"].add(account_text)
+        for field in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_tokens",
+            "cache_read_tokens",
+            "reasoning_tokens",
+            "total_tokens",
+        ):
+            bucket[field] += as_int(record.get(field))
+        bucket["cost_usd"] += as_float(record.get("cost_usd"))
+
+    daily = []
+    for bucket in buckets.values():
+        row = dict(bucket)
+        row["sessions"] = len(bucket["sessions"])
+        row["hosts"] = ",".join(sorted(bucket["hosts"]))
+        row["accounts"] = ",".join(sorted(bucket["accounts"]))
+        row["cost_usd"] = round(row["cost_usd"], 10)
+        daily.append(row)
+    daily.sort(key=lambda item: (item["date"], item["host"], item["source"], item["service"], item["model"]))
+    return daily
+
+
+def write_csv(path: Path, records: list[dict[str, Any]]) -> None:
+    columns = [
+        "date",
+        "timestamp",
+        "host",
+        "host_label",
+        "account_label",
+        "source",
+        "service",
+        "account",
+        "provider",
+        "model",
+        "session_id",
+        "project",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "reasoning_tokens",
+        "total_tokens",
+        "cost_usd",
+        "from_cache",
+        "cache_collected_at",
+        "source_path",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record)
+
+
+def write_daily_csv(path: Path, records: list[dict[str, Any]]) -> None:
+    columns = [
+        "date",
+        "host",
+        "account_label",
+        "source",
+        "service",
+        "provider",
+        "model",
+        "account",
+        "hosts",
+        "accounts",
+        "records",
+        "sessions",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_tokens",
+        "cache_read_tokens",
+        "reasoning_tokens",
+        "total_tokens",
+        "cost_usd",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        for record in records:
+            writer.writerow(record)
+
+
+def build_combined(host_payloads: list[tuple[HostSpec, dict[str, Any], bool]], statuses: list[dict[str, Any]]) -> dict[str, Any]:
+    records: list[dict[str, Any]] = []
+    for spec, payload, cached in host_payloads:
+        records.extend(add_host_context(payload, spec, cached))
+    records.sort(key=lambda item: (item.get("timestamp") or "", item.get("host") or "", item.get("source") or ""))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "statuses": statuses,
+        "summary": summarize_records(records),
+        "records": records,
+    }
+
+
+def default_specs(include_local: bool) -> list[HostSpec]:
+    if include_local:
+        return [HostSpec(label=socket.gethostname().split(".", 1)[0], target="local")]
+    return []
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect Claude Code, Codex, opencode, and pi usage into JSON/CSV without copying prompts."
+    )
+    parser.add_argument("--inventory", type=Path, help="Host inventory file. Lines are 'label ssh-target account=name'.")
+    parser.add_argument("--host", action="append", default=[], help="Remote host, or label=ssh-target. Can be repeated.")
+    parser.add_argument("--no-local", action="store_true", help="Skip local collection.")
+    parser.add_argument("--cache-dir", type=Path, default=Path(DEFAULT_CACHE_DIR), help=f"Per-host cache directory, default {DEFAULT_CACHE_DIR}.")
+    parser.add_argument("--output-json", type=Path, default=Path(DEFAULT_JSON), help=f"Combined JSON output, default {DEFAULT_JSON}.")
+    parser.add_argument("--output-csv", type=Path, default=Path(DEFAULT_CSV), help=f"Combined CSV output, default {DEFAULT_CSV}.")
+    parser.add_argument("--daily-json", type=Path, default=Path(DEFAULT_DAILY_JSON), help=f"Daily aggregate JSON output, default {DEFAULT_DAILY_JSON}.")
+    parser.add_argument("--daily-csv", type=Path, default=Path(DEFAULT_DAILY_CSV), help=f"Daily aggregate CSV output, default {DEFAULT_DAILY_CSV}.")
+    parser.add_argument("--no-daily", action="store_true", help="Skip daily aggregate outputs.")
+    parser.add_argument("--daily-split-hosts", action="store_true", help="Keep hosts separate in daily aggregates instead of merging them.")
+    parser.add_argument("--daily-split-accounts", action="store_true", help="Keep accounts separate in daily aggregates instead of merging them.")
+    parser.add_argument("--ssh-timeout", type=int, default=8, help="SSH connect timeout in seconds.")
+    parser.add_argument(
+        "--claude-cost-source",
+        choices=("auto", "raw", "ccusage", "npx"),
+        default="auto",
+        help="Claude Code source: auto uses installed ccusage or npx ccusage@latest, raw parses JSONL only.",
+    )
+    parser.add_argument("--json-only", action="store_true", help="Do not write CSV output.")
+    parser.add_argument("--collect-local", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--host-label", default="", help=argparse.SUPPRESS)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.collect_local:
+        print(json.dumps(collect_local(args.host_label, args.claude_cost_source), sort_keys=True))
+        return 0
+
+    specs = default_specs(not args.no_local)
+    if args.inventory:
+        specs.extend(parse_inventory(args.inventory))
+    specs.extend(parse_host_arg(value) for value in args.host)
+
+    # Later specs with the same label replace earlier ones, which lets inventory
+    # override the implicit local host cleanly.
+    deduped: dict[str, HostSpec] = {}
+    for spec in specs:
+        deduped[spec.label] = spec
+    specs = list(deduped.values())
+    if not specs:
+        raise SystemExit("No hosts selected. Use --host, --inventory, or omit --no-local.")
+
+    host_payloads: list[tuple[HostSpec, dict[str, Any], bool]] = []
+    statuses: list[dict[str, Any]] = []
+    for spec in specs:
+        payload, status = collect_host(spec, args.cache_dir, args.ssh_timeout, args.claude_cost_source)
+        statuses.append(status)
+        if payload is None:
+            eprint(f"{spec.label}: no data ({status.get('message')})")
+            continue
+        cached = status.get("status") == "cached"
+        label = "cached" if cached else "updated"
+        eprint(f"{spec.label}: {label}, {len(payload.get('records', []))} records")
+        host_payloads.append((spec, payload, cached))
+
+    combined = build_combined(host_payloads, statuses)
+    atomic_write_json(args.output_json, combined)
+    if not args.json_only:
+        write_csv(args.output_csv, combined["records"])
+    if not args.no_daily:
+        daily = aggregate_daily(
+            combined["records"],
+            split_hosts=args.daily_split_hosts,
+            split_accounts=args.daily_split_accounts,
+        )
+        atomic_write_json(
+            args.daily_json,
+            {
+                "schema_version": SCHEMA_VERSION,
+                "generated_at": combined["generated_at"],
+                "summary": summarize_records(daily),
+                "records": daily,
+            },
+        )
+        if not args.json_only:
+            write_daily_csv(args.daily_csv, daily)
+    eprint(f"Wrote {args.output_json}")
+    if not args.json_only:
+        eprint(f"Wrote {args.output_csv}")
+    if not args.no_daily:
+        eprint(f"Wrote {args.daily_json}")
+        if not args.json_only:
+            eprint(f"Wrote {args.daily_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -839,23 +839,16 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .chart-head h2 { margin: 0; }
 .scale-control { display: flex; align-items: center; gap: 8px; color: var(--muted); font: 11px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; text-transform: uppercase; letter-spacing: .12em; }
 .scale-control select { color: var(--ink); background: var(--paper); border: 1px solid var(--rule); padding: 6px 8px; font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-.chart-body { display: grid; grid-template-columns: 58px minmax(0, 1fr) 58px; gap: 10px; align-items: start; }
-.chart-stack { min-width: 0; }
-.y-axis { position: relative; height: 230px; border-bottom: 1px solid transparent; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-.y-tick { position: absolute; right: 0; transform: translateY(50%); white-space: nowrap; }
-.cost-y-axis .y-tick { left: 0; right: auto; color: var(--gold); }
-.chart { position: relative; display: flex; align-items: flex-end; gap: 3px; height: 230px; padding: 10px 0 0; border-bottom: 1px solid var(--rule); }
-.gridline { position: absolute; left: 0; right: 0; border-top: 1px solid rgba(237,228,209,.08); z-index: 0; }
-.cost-overlay { position: absolute; inset: 10px 0 0 0; width: 100%; height: calc(100% - 10px); z-index: 3; pointer-events: none; overflow: visible; }
-.cost-overlay path { fill: none; stroke: var(--gold); stroke-width: 3; vector-effect: non-scaling-stroke; }
-.cost-overlay circle { fill: var(--paper); stroke: var(--gold); stroke-width: 2; vector-effect: non-scaling-stroke; }
-.day { position: relative; z-index: 1; flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
-.day:hover { outline: 1px solid var(--gold); outline-offset: 2px; opacity: 1; }
-.seg.in { background: var(--in); } .seg.out { background: var(--out); } .seg.cw { background: var(--cw); } .seg.cr { background: var(--cr); } .seg.rz { background: var(--rz); }
-.chart-axis { position: relative; height: 22px; margin: 8px 0 12px; overflow: hidden; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
-.axis-tick { position: absolute; transform: translateX(-50%); white-space: nowrap; }
-.axis-tick:first-child { transform: translateX(0); }
-.axis-tick:last-child { transform: translateX(-100%); }
+.chart-body { min-width: 0; }
+.chart { height: 320px; border-bottom: 1px solid var(--rule); }
+.chart svg { display: block; width: 100%; height: 100%; overflow: visible; }
+.chart .axis path, .chart .axis line { stroke: var(--rule-strong); }
+.chart .axis text { fill: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.chart .cost-axis text { fill: var(--gold); }
+.chart .grid line { stroke: rgba(237,228,209,.08); }
+.chart .grid path { display: none; }
+.chart .cost-line { fill: none; stroke: var(--gold); stroke-width: 3; vector-effect: non-scaling-stroke; }
+.chart .cost-dot { fill: var(--paper); stroke: var(--gold); stroke-width: 2; vector-effect: non-scaling-stroke; }
 .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 10px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .swatch { display: inline-block; width: 10px; height: 10px; margin-right: 5px; vertical-align: -1px; }
 .swatch.line { height: 2px; width: 18px; vertical-align: 3px; }
@@ -925,12 +918,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
         <label class="scale-control">Y scale <select id="tokenScale"><option value="log" selected>Log</option><option value="linear">Linear</option></select></label>
       </div>
       <div class="chart-body">
-        <div id="yAxis" class="y-axis" aria-label="Daily token y axis"></div>
-        <div class="chart-stack">
-          <div id="chart" class="chart" aria-label="Daily token bars and reported cost curve"></div>
-          <div id="chartAxis" class="chart-axis" aria-label="Daily token date axis"></div>
-        </div>
-        <div id="costYAxis" class="y-axis cost-y-axis" aria-label="Daily cost y axis"></div>
+        <div id="chart" class="chart" aria-label="Daily token bars and reported cost curve"></div>
       </div>
       <div class="legend">
         <span><i class="swatch" style="background:var(--in)"></i>input</span>
@@ -978,6 +966,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
   </section>
 </main>
 <div id="hovercard" class="hovercard"></div>
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 <script id="usage-data" type="application/json">__DATA__</script>
 <script>
 const D = JSON.parse(document.getElementById('usage-data').textContent);
@@ -1038,101 +1027,134 @@ function dateLabel(date) {
   const parsed = new Date(date + 'T00:00:00Z');
   return parsed.toLocaleDateString('en', {month: 'short', day: 'numeric', timeZone: 'UTC'});
 }
-function scaleRatio(value, max) {
-  value = Number(value || 0); max = Number(max || 0);
-  if (!value || !max) return 0;
-  if (state.tokenScale === 'log') return Math.log10(value + 1) / Math.log10(max + 1);
-  return value / max;
+function d3TokenScale(max, height) {
+  if (state.tokenScale === 'log') return d3.scaleLog().domain([1, Math.max(1, max)]).range([height, 0]).clamp(true);
+  return d3.scaleLinear().domain([0, Math.max(1, max)]).nice().range([height, 0]);
 }
-function yTicks(max) {
+function d3Value(scale, value, height) {
+  value = Number(value || 0);
+  if (!value) return height;
+  if (state.tokenScale === 'log') return scale(Math.max(1, value));
+  return scale(value);
+}
+function d3Ticks(max) {
   max = Number(max || 0);
   if (!max) return [0];
-  if (state.tokenScale === 'log') {
-    const ticks = [0];
-    let value = 1;
-    while (value < max) { ticks.push(value); value *= 10; }
-    if (!ticks.includes(max)) ticks.push(max);
-    return ticks.filter((value, index, arr) => index === 0 || value === max || value >= max / 100000 || arr.length <= 7).slice(-7);
-  }
-  return [0, .25, .5, .75, 1].map(ratio => Math.round(max * ratio));
-}
-function renderYAxis(max, axisId, formatter, drawGrid) {
-  const axis = clear(axisId);
-  const chart = document.getElementById('chart');
-  if (drawGrid) chart.querySelectorAll('.gridline').forEach(line => line.remove());
-  yTicks(max).forEach(value => {
-    const ratio = scaleRatio(value, max);
-    const bottom = Math.max(0, Math.min(100, ratio * 100));
-    const tick = node('span', 'y-tick', formatter(value));
-    tick.style.bottom = bottom + '%';
-    axis.append(tick);
-    if (drawGrid) {
-      const line = node('i', 'gridline');
-      line.style.bottom = bottom + '%';
-      chart.append(line);
-    }
-  });
-}
-function renderChartAxis(days) {
-  const axis = clear('chartAxis');
-  if (!days.length) return;
-  const count = Math.min(7, days.length);
-  const used = new Set();
-  for (let i = 0; i < count; i += 1) {
-    const index = count === 1 ? 0 : Math.round(i * (days.length - 1) / (count - 1));
-    if (used.has(index)) continue;
-    used.add(index);
-    const tick = node('span', 'axis-tick', dateLabel(days[index].date));
-    tick.style.left = days.length === 1 ? '0%' : `${index / (days.length - 1) * 100}%`;
-    axis.append(tick);
-  }
-}
-function renderCostOverlay(root, days, maxCost) {
-  renderYAxis(maxCost, 'costYAxis', usd, false);
-  if (!days.length || !maxCost) return;
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-  svg.setAttribute('class', 'cost-overlay');
-  svg.setAttribute('viewBox', '0 0 1000 100');
-  svg.setAttribute('preserveAspectRatio', 'none');
-  const points = days.map((d, i) => {
-    const x = days.length === 1 ? 0 : i * (1000 / (days.length - 1));
-    const y = 100 - (scaleRatio(Number(d.cost_usd || 0), maxCost) * 100);
-    return [x, y];
-  });
-  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-  path.setAttribute('d', points.map(([x, y], index) => `${index ? 'L' : 'M'}${x.toFixed(1)},${y.toFixed(1)}`).join(' '));
-  svg.append(path);
-  points.forEach(([x, y], index) => {
-    if (days.length > 120 && index % Math.ceil(days.length / 60) !== 0) return;
-    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-    circle.setAttribute('cx', x.toFixed(1));
-    circle.setAttribute('cy', y.toFixed(1));
-    circle.setAttribute('r', '2.3');
-    svg.append(circle);
-  });
-  root.append(svg);
+  if (state.tokenScale !== 'log') return null;
+  const ticks = [];
+  let value = 1;
+  while (value < max) { ticks.push(value); value *= 10; }
+  ticks.push(max);
+  return ticks.filter((value, index, arr) => index === arr.length - 1 || value >= max / 100000).slice(-7);
 }
 function renderChart(days) {
-  const root = clear('chart');
-  const maxTokens = Math.max(1, ...days.map(d => Number(d.total_tokens || 0)));
-  const maxCost = Math.max(0, ...days.map(d => Number(d.cost_usd || 0)));
-  renderYAxis(maxTokens, 'yAxis', fmt, true);
-  days.forEach(d => {
-    const total = Number(d.total_tokens || 0);
-    const scaledTotal = scaleRatio(total, maxTokens) * 100;
-    const day = node('div','day');
-    day.title = `${d.date} · ${fmt(total)} tokens · ${usd(d.cost_usd)} · ${state.tokenScale} scale`;
-    fields.forEach((f, idx) => {
-      const seg = node('div', 'seg ' + segClass[idx]);
-      const share = total ? Number(d[f] || 0) / total : 0;
-      const height = scaledTotal * share;
-      seg.style.height = height ? Math.max(.8, height) + '%' : '0';
-      day.append(seg);
+  const rootNode = clear('chart');
+  if (!window.d3) {
+    rootNode.append(node('div', 'note', 'D3 failed to load; chart unavailable.'));
+    return;
+  }
+  const root = d3.select(rootNode);
+  const width = Math.max(760, rootNode.clientWidth || 900);
+  const height = 320;
+  const margin = {top: 18, right: 72, bottom: 38, left: 70};
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+  const maxTokens = d3.max(days, d => Number(d.total_tokens || 0)) || 1;
+  const maxCost = d3.max(days, d => Number(d.cost_usd || 0)) || 0;
+  const x = d3.scaleBand().domain(days.map(d => d.date)).range([margin.left, margin.left + innerWidth]).paddingInner(0.18).paddingOuter(0.05);
+  const yTokens = d3TokenScale(maxTokens, innerHeight);
+  const yCost = d3TokenScale(maxCost || 1, innerHeight);
+  const tokenValue = value => margin.top + d3Value(yTokens, value, innerHeight);
+  const costValue = value => margin.top + d3Value(yCost, value, innerHeight);
+  const barBase = margin.top + innerHeight;
+  const svg = root.append('svg').attr('viewBox', `0 0 ${width} ${height}`).attr('role', 'img').attr('aria-label', 'Daily token bars with reported cost curve');
+  const tokenTicks = d3Ticks(maxTokens);
+  const costTicks = d3Ticks(maxCost || 1);
+  const xTickCount = Math.min(7, days.length);
+  const xTickValues = [];
+  for (let i = 0; i < xTickCount; i += 1) {
+    const index = xTickCount === 1 ? 0 : Math.round(i * (days.length - 1) / (xTickCount - 1));
+    if (days[index] && !xTickValues.includes(days[index].date)) xTickValues.push(days[index].date);
+  }
+  svg.append('g')
+    .attr('class', 'grid')
+    .attr('transform', `translate(${margin.left},${margin.top})`)
+    .call(d3.axisLeft(yTokens).tickValues(tokenTicks).ticks(5, '~s').tickSize(-innerWidth).tickFormat(''));
+  svg.append('g')
+    .attr('class', 'axis token-axis')
+    .attr('transform', `translate(${margin.left},${margin.top})`)
+    .call(d3.axisLeft(yTokens).tickValues(tokenTicks).ticks(5, '~s').tickFormat(d => fmt(d)));
+  svg.append('g')
+    .attr('class', 'axis cost-axis')
+    .attr('transform', `translate(${margin.left + innerWidth},${margin.top})`)
+    .call(d3.axisRight(yCost).tickValues(costTicks).ticks(5, '~s').tickFormat(d => usd(d)));
+  svg.append('g')
+    .attr('class', 'axis x-axis')
+    .attr('transform', `translate(0,${barBase})`)
+    .call(d3.axisBottom(x).tickValues(xTickValues).tickFormat(dateLabel));
+  const bars = svg.append('g').attr('class', 'token-bars');
+  days.forEach(day => {
+    const total = Number(day.total_tokens || 0);
+    let cursor = barBase;
+    fields.forEach((field, idx) => {
+      const value = Number(day[field] || 0);
+      const share = total ? value / total : 0;
+      const totalHeight = barBase - tokenValue(total);
+      const segmentHeight = totalHeight * share;
+      cursor -= segmentHeight;
+      bars.append('rect')
+        .attr('x', x(day.date))
+        .attr('y', cursor)
+        .attr('width', Math.max(1, x.bandwidth()))
+        .attr('height', Math.max(0, segmentHeight))
+        .attr('fill', `var(--${segClass[idx]})`)
+        .append('title').text(`${day.date} · ${fmt(value)} ${field.replaceAll('_', ' ')} · ${fmt(total)} total · ${usd(day.cost_usd)}`);
     });
-    root.append(day);
   });
-  renderCostOverlay(root, days, maxCost);
-  renderChartAxis(days);
+  const line = d3.line()
+    .defined(d => Number(d.cost_usd || 0) > 0)
+    .x(d => (x(d.date) || margin.left) + x.bandwidth() / 2)
+    .y(d => costValue(Number(d.cost_usd || 0)));
+  svg.append('path').datum(days).attr('class', 'cost-line').attr('d', line);
+  const dotEvery = days.length > 120 ? Math.ceil(days.length / 60) : 1;
+  svg.append('g').selectAll('circle')
+    .data(days.filter((d, i) => Number(d.cost_usd || 0) > 0 && i % dotEvery === 0))
+    .join('circle')
+    .attr('class', 'cost-dot')
+    .attr('cx', d => (x(d.date) || margin.left) + x.bandwidth() / 2)
+    .attr('cy', d => costValue(Number(d.cost_usd || 0)))
+    .attr('r', 2.4)
+    .append('title').text(d => `${d.date} · ${usd(d.cost_usd)} reported cost · ${fmt(d.total_tokens)} tokens`);
+  const focus = svg.append('g').attr('class', 'chart-focus').style('display', 'none');
+  focus.append('line').attr('y1', margin.top).attr('y2', barBase).attr('stroke', 'var(--gold)').attr('stroke-width', 1).attr('stroke-dasharray', '3 3');
+  focus.append('circle').attr('r', 4).attr('fill', 'var(--paper)').attr('stroke', 'var(--gold)').attr('stroke-width', 2);
+  svg.append('rect')
+    .attr('x', margin.left)
+    .attr('y', margin.top)
+    .attr('width', innerWidth)
+    .attr('height', innerHeight)
+    .attr('fill', 'transparent')
+    .on('mouseenter', () => focus.style('display', null))
+    .on('mouseleave', () => { focus.style('display', 'none'); hideHover(); })
+    .on('mousemove', event => {
+      if (!days.length) return;
+      const [mx] = d3.pointer(event);
+      const step = innerWidth / Math.max(1, days.length);
+      const index = Math.max(0, Math.min(days.length - 1, Math.floor((mx - margin.left) / step)));
+      const day = days[index];
+      const cx = (x(day.date) || margin.left) + x.bandwidth() / 2;
+      const cy = Number(day.cost_usd || 0) ? costValue(Number(day.cost_usd || 0)) : tokenValue(Number(day.total_tokens || 0));
+      focus.select('line').attr('x1', cx).attr('x2', cx);
+      focus.select('circle').attr('cx', cx).attr('cy', cy);
+      showHover(event, [
+        day.date,
+        `${fmt(day.total_tokens)} total tokens`,
+        `${fmt(day.input_tokens)} in · ${fmt(day.output_tokens)} out`,
+        `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache`,
+        `${usd(day.cost_usd)} reported cost`,
+        `${state.tokenScale} scale`,
+      ]);
+    });
 }
 function renderServices(services) {
   const palette = ['#d8a33d','#8fb8b6','#577f86','#7d6c9f','#d66b55','#77b77a','#ede4d1'];

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -976,6 +976,11 @@ let state = { from: null, to: null, preset: 'all', hosts: ['all'], tokenScale: '
 function fmt(n) { n = Number(n || 0); if (n >= 1e9) return (n/1e9).toFixed(1)+'B'; if (n >= 1e6) return (n/1e6).toFixed(1)+'M'; if (n >= 1e3) return (n/1e3).toFixed(0)+'k'; return String(Math.round(n)); }
 function usd(n) { return '$' + Number(n || 0).toFixed(2); }
 function pct(n) { return Number(n || 0).toFixed(1) + '%'; }
+function providerCostLines(day) {
+  const costs = Object.entries(day.provider_costs || {}).filter(([, value]) => Number(value || 0) > 0).sort((a, b) => Number(b[1]) - Number(a[1]));
+  if (!costs.length) return ['provider cost: none reported'];
+  return ['provider cost', ...costs.map(([provider, value]) => `${provider}: ${usd(value)}`)];
+}
 function node(tag, cls, text) { const el = document.createElement(tag); if (cls) el.className = cls; if (text !== undefined) el.textContent = text; return el; }
 function clear(id) { const el = document.getElementById(id); while (el.firstChild) el.removeChild(el.firstChild); return el; }
 function addTotals(target, row) { fields.concat(['total_tokens']).forEach(f => target[f] = Number(target[f] || 0) + Number(row[f] || 0)); target.cost_usd = Number(target.cost_usd || 0) + Number(row.cost_usd || 0); target.records = Number(target.records || 0) + Number(row.records || 0); target.sessions = Number(target.sessions || 0) + Number(row.sessions || 0); }
@@ -995,12 +1000,14 @@ function derive(rows) {
   const daysMap = new Map(), modelsMap = new Map(), servicesMap = new Map();
   rows.forEach(row => {
     if (!row.date) return;
-    if (!daysMap.has(row.date)) daysMap.set(row.date, {date: row.date, records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
-    addTotals(daysMap.get(row.date), row);
+    const provider = providerGroup(row);
+    if (!daysMap.has(row.date)) daysMap.set(row.date, {date: row.date, records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0, provider_costs:{}});
+    const dayBucket = daysMap.get(row.date);
+    addTotals(dayBucket, row);
+    dayBucket.provider_costs[provider] = Number(dayBucket.provider_costs[provider] || 0) + Number(row.cost_usd || 0);
     const modelKey = [row.service, row.provider, row.model].join('\u0000');
     if (!modelsMap.has(modelKey)) modelsMap.set(modelKey, {service: row.service, provider: row.provider, model: row.model, days: new Set(), sources: new Set(), hosts: new Set(), accounts: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
     const model = modelsMap.get(modelKey); addTotals(model, row); model.days.add(row.date); model.sources.add(row.source); (row.hosts || '').split(',').filter(Boolean).forEach(v => model.hosts.add(v)); (row.accounts || '').split(',').filter(Boolean).forEach(v => model.accounts.add(v));
-    const provider = providerGroup(row);
     if (!servicesMap.has(provider)) servicesMap.set(provider, {provider, sources: new Set(), records:0, sessions:0, input_tokens:0, output_tokens:0, cache_creation_tokens:0, cache_read_tokens:0, reasoning_tokens:0, total_tokens:0, cost_usd:0});
     const serviceBucket = servicesMap.get(provider);
     serviceBucket.sources.add(row.source);
@@ -1152,6 +1159,7 @@ function renderChart(days) {
         `${fmt(day.input_tokens)} in · ${fmt(day.output_tokens)} out`,
         `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache`,
         `${usd(day.cost_usd)} reported cost`,
+        ...providerCostLines(day),
         `${state.tokenScale} scale`,
       ]);
     });
@@ -1226,13 +1234,13 @@ function renderHeatmap(rootId, monthsId, maxId, days, field, formatter, costMode
     for (let i = 0; i < firstDow; i += 1) root.append(node('i', 'cell empty'));
   }
   calendar.forEach(date => {
-    const day = byDate.get(date) || {date, total_tokens: 0, cost_usd: 0, input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, reasoning_tokens: 0};
+    const day = byDate.get(date) || {date, total_tokens: 0, cost_usd: 0, input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, reasoning_tokens: 0, provider_costs: {}};
     const value = Number(day[field] || 0);
     const level = heatLevel(value, max);
     const cell = node('i', `cell${costMode ? ' cost' : ''}${level ? ' l' + level : ''}`);
     const lines = costMode
-      ? [date, `${formatter(value)} reported cost`, `${fmt(day.total_tokens || 0)} tokens`]
-      : [date, `${formatter(value)} total tokens`, `${fmt(day.input_tokens || 0)} in · ${fmt(day.output_tokens || 0)} out`, `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache · ${usd(day.cost_usd || 0)}`];
+      ? [date, `${formatter(value)} reported cost`, `${fmt(day.total_tokens || 0)} tokens`, ...providerCostLines(day)]
+      : [date, `${formatter(value)} total tokens`, `${fmt(day.input_tokens || 0)} in · ${fmt(day.output_tokens || 0)} out`, `${fmt((day.cache_creation_tokens || 0) + (day.cache_read_tokens || 0))} cache · ${usd(day.cost_usd || 0)}`, ...providerCostLines(day)];
     cell.setAttribute('aria-label', lines.join(' · '));
     cell.addEventListener('mouseenter', event => showHover(event, lines));
     cell.addEventListener('mousemove', moveHover);

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -26,6 +26,7 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 DEFAULT_CACHE_DIR = ".ai-usage-cache"
+DEFAULT_INVENTORY = "ai-usage.hosts"
 DEFAULT_JSON = "ai-usage.json"
 DEFAULT_CSV = "ai-usage.csv"
 DEFAULT_DAILY_JSON = "ai-usage-daily.json"
@@ -1227,10 +1228,10 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Collect Claude Code, Codex, opencode, and pi usage into JSON/CSV without copying prompts."
     )
-    parser.add_argument("--inventory", type=Path, help="Host inventory file. Lines are 'label ssh-target account=name'.")
+    parser.add_argument("--inventory", type=Path, help=f"Host inventory file. Defaults to {DEFAULT_INVENTORY} next to this script when present.")
     parser.add_argument("--host", action="append", default=[], help="Remote host, or label=ssh-target. Can be repeated.")
     parser.add_argument("--no-local", action="store_true", help="Skip local collection.")
-    parser.add_argument("--cache-dir", type=Path, default=Path(DEFAULT_CACHE_DIR), help=f"Per-host cache directory, default {DEFAULT_CACHE_DIR}.")
+    parser.add_argument("--cache-dir", type=Path, help=f"Per-host cache directory. Defaults to {DEFAULT_CACHE_DIR} next to this script.")
     parser.add_argument("--output-json", type=Path, default=Path(DEFAULT_JSON), help=f"Combined JSON output, default {DEFAULT_JSON}.")
     parser.add_argument("--output-csv", type=Path, default=Path(DEFAULT_CSV), help=f"Combined CSV output, default {DEFAULT_CSV}.")
     parser.add_argument("--daily-json", type=Path, default=Path(DEFAULT_DAILY_JSON), help=f"Daily aggregate JSON output, default {DEFAULT_DAILY_JSON}.")
@@ -1259,9 +1260,17 @@ def main() -> int:
         print(json.dumps(collect_local(args.host_label, args.ccusage_runner), sort_keys=True))
         return 0
 
+    script_dir = Path(__file__).resolve().parent
+    cache_dir = args.cache_dir or script_dir / DEFAULT_CACHE_DIR
+
     specs = default_specs(not args.no_local)
-    if args.inventory:
-        specs.extend(parse_inventory(args.inventory))
+    inventory_path = args.inventory
+    if inventory_path is None:
+        inventory_path = script_dir / DEFAULT_INVENTORY
+    if inventory_path.exists():
+        specs.extend(parse_inventory(inventory_path))
+    elif args.inventory:
+        raise SystemExit(f"Inventory file not found: {inventory_path}")
     specs.extend(parse_host_arg(value) for value in args.host)
 
     # Later specs with the same label replace earlier ones, which lets inventory
@@ -1276,7 +1285,7 @@ def main() -> int:
     host_payloads: list[tuple[HostSpec, dict[str, Any], bool]] = []
     statuses: list[dict[str, Any]] = []
     for spec in specs:
-        payload, status = collect_host(spec, args.cache_dir, args.ssh_timeout, args.ccusage_runner)
+        payload, status = collect_host(spec, cache_dir, args.ssh_timeout, args.ccusage_runner)
         statuses.append(status)
         if payload is None:
             eprint(f"{spec.label}: no data ({status.get('message')})")

--- a/ai-usage-collect.py
+++ b/ai-usage-collect.py
@@ -78,16 +78,27 @@ def as_float(value: Any) -> float:
         return 0.0
 
 
+def clean_ccusage_model_name(model: str) -> str:
+    return re.sub(r"^\[[^\]]+\]\s*", "", model).strip()
+
+
 def infer_service(source: str, provider: str, model: str) -> str:
-    haystack = f"{source} {provider} {model}".lower()
+    normalized_model = clean_ccusage_model_name(model).lower()
+    haystack = f"{source} {provider} {normalized_model}".lower()
     if "grok" in haystack or "xai" in haystack or "x.ai" in haystack:
         return "grok"
     if "claude" in haystack or "anthropic" in haystack:
         return "claude"
     if "codex" in haystack:
         return "codex"
-    if "openai" in haystack or model.startswith("gpt-") or model.startswith("o"):
+    if "gemini" in haystack:
+        return "gemini"
+    if "openai" in haystack or normalized_model.startswith("gpt-") or normalized_model.startswith("o"):
         return "openai"
+    if "kimi" in haystack:
+        return "kimi"
+    if "qwen" in haystack:
+        return "qwen"
     return source
 
 
@@ -213,7 +224,7 @@ def collect_ccusage_unified(home: Path, mode: str = "auto") -> list[dict[str, An
                 for breakdown in breakdowns:
                     if not isinstance(breakdown, dict):
                         continue
-                    model = str(breakdown.get("modelName") or "")
+                    model = clean_ccusage_model_name(str(breakdown.get("modelName") or ""))
                     records.append(
                         new_record(
                             source=source,
@@ -820,18 +831,21 @@ h1 { margin: 0; font-size: clamp(38px, 7vw, 92px); line-height: .88; letter-spac
 .rangebar button.active, .rangebar button:hover, .rangebar input:focus, .rangebar select:focus { border-color: var(--gold); outline: 0; }
 .custom-range { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .range-readout { color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; margin-left: 6px; }
-.grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 28px; margin-top: 30px; }
+.grid { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 28px; margin-top: 30px; align-items: start; }
 .panel { border-top: 1px solid var(--rule-strong); padding-top: 14px; min-width: 0; }
+.flow-panel { overflow: hidden; padding-bottom: 8px; }
 .panel h2 { margin: 0 0 14px; font-size: 22px; font-weight: 500; letter-spacing: -.02em; }
 .chart { display: flex; align-items: flex-end; gap: 3px; height: 230px; padding: 10px 0 0; border-bottom: 1px solid var(--rule); }
 .day { flex: 1 1 3px; min-width: 3px; height: 100%; display: flex; flex-direction: column-reverse; justify-content: flex-start; opacity: .94; }
 .day:hover { outline: 1px solid var(--gold); outline-offset: 2px; opacity: 1; }
 .seg.in { background: var(--in); } .seg.out { background: var(--out); } .seg.cw { background: var(--cw); } .seg.cr { background: var(--cr); } .seg.rz { background: var(--rz); }
-.chart-axis { position: relative; height: 18px; margin-top: 6px; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.chart-axis { position: relative; height: 22px; margin: 8px 0 12px; overflow: hidden; color: var(--muted); font: 10px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .axis-tick { position: absolute; transform: translateX(-50%); white-space: nowrap; }
+.axis-tick:first-child { transform: translateX(0); }
+.axis-tick:last-child { transform: translateX(-100%); }
 .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 10px; color: var(--muted); font: 12px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
 .swatch { display: inline-block; width: 10px; height: 10px; margin-right: 5px; vertical-align: -1px; }
-.costline { width: 100%; height: 74px; margin-top: 8px; overflow: visible; }
+.costline { display: block; width: 100%; height: 74px; margin-top: 10px; overflow: hidden; }
 .heatmaps { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; margin-top: 30px; }
 .heatmap-wrap { border-top: 1px solid var(--rule); padding-top: 12px; min-width: 0; }
 .heatmap-head { display: flex; justify-content: space-between; gap: 12px; align-items: baseline; margin-bottom: 10px; }
@@ -892,7 +906,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
     </div>
   </section>
   <section class="grid">
-    <div class="panel">
+    <div class="panel flow-panel">
       <h2>Daily Token Flow</h2>
       <div id="chart" class="chart" aria-label="Daily token bars"></div>
       <div id="chartAxis" class="chart-axis" aria-label="Daily token date axis"></div>
@@ -929,7 +943,7 @@ td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
       <div class="heatmap-legend"><span>less</span><i class="cell cost"></i><i class="cell cost l1"></i><i class="cell cost l2"></i><i class="cell cost l3"></i><i class="cell cost l4"></i><span>more</span></div>
     </div>
   </section>
-  <section class="panel" style="margin-top:30px">
+  <section class="panel" style="margin-top:42px">
     <h2>Top Models</h2>
     <table>
       <thead><tr><th>Model</th><th class="num">Days</th><th class="num">Input</th><th class="num">Output</th><th class="num">Cache</th><th class="num">Total</th><th class="num">Cost</th></tr></thead>
@@ -1122,6 +1136,12 @@ function hostSummary(hosts) {
   if (list.length <= 3) return list.join(', ');
   return `${list.slice(0, 3).join(', ')} +${list.length - 3}`;
 }
+function routeSummary(row) {
+  const sources = (row.sources || []).filter(Boolean);
+  const via = sources.length ? `via ${sources.join(', ')}` : '';
+  const service = row.service || '';
+  return [service, via, hostSummary(row.hosts)].filter(Boolean).join(' · ');
+}
 function renderModels(models) {
   const body = clear('models');
   models.slice(0, 30).forEach(row => {
@@ -1129,7 +1149,7 @@ function renderModels(models) {
     const name = document.createElement('td');
     name.title = `sources: ${(row.sources || []).join(', ')}; hosts: ${(row.hosts || []).join(', ')}; accounts: ${(row.accounts || []).join(', ')}`;
     name.append(node('div','model-name',row.model || 'unknown'));
-    name.append(node('div','meta',`${row.service || 'unknown'} ${row.provider ? '· '+row.provider : ''} · ${hostSummary(row.hosts)}`));
+    name.append(node('div','meta',routeSummary(row)));
     tr.append(name);
     [['days',fmt(row.days)],['input',fmt(row.input_tokens)],['output',fmt(row.output_tokens)],['cache',fmt(Number(row.cache_creation_tokens || 0)+Number(row.cache_read_tokens || 0))],['total',fmt(row.total_tokens)],['cost',usd(row.cost_usd)]].forEach(([, value]) => tr.append(node('td','num',value)));
     body.append(tr);

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -1,0 +1,91 @@
+# ai-usage-collect.py
+
+Collect AI coding-agent usage from local and SSH-reachable machines into JSON and CSV files.
+
+## Why
+
+Usage lives in different places depending on the tool: Claude Code JSONL, Codex session files, pi session files, and opencode SQLite. This script normalizes those records without copying prompts, responses, tool arguments, auth files, or raw transcripts.
+
+It keeps a per-host cache, so an offline host does not erase its last known usage.
+
+## Requirements
+
+- `python3`
+- `ssh` for remote hosts
+- `ccusage` or `npx` for Claude Code cost data. By default the script tries installed `ccusage`, then `npx --yes ccusage@latest`, then falls back to raw Claude JSONL tokens.
+
+No Python packages are required.
+
+## Usage
+
+```bash
+./ai-usage-collect.py [OPTIONS]
+```
+
+Default outputs:
+
+| File | Description |
+|------|-------------|
+| `ai-usage.json` | Raw normalized records from every collected host |
+| `ai-usage.csv` | CSV version of raw records |
+| `ai-usage-daily.json` | Daily per-model aggregates |
+| `ai-usage-daily.csv` | CSV version of daily aggregates |
+| `.ai-usage-cache/<host>.json` | Last successful snapshot for each host |
+
+## Examples
+
+```bash
+# Collect this machine only
+./ai-usage-collect.py
+
+# Collect local plus two SSH hosts
+./ai-usage-collect.py --host eqr5 --host macbook=stone@macbook.local
+
+# Use an inventory file
+./ai-usage-collect.py --inventory ai-usage.hosts
+
+# Keep hosts separate in the daily aggregate
+./ai-usage-collect.py --daily-split-hosts
+
+# Avoid network calls for Claude Code and parse raw JSONL only
+./ai-usage-collect.py --claude-cost-source raw
+```
+
+Inventory format:
+
+```text
+# label ssh-target optional key=value metadata
+local local account=personal
+eqr5 stone@eqr5.local account=personal
+work-mac stone@work-mac.local account=work
+```
+
+Daily aggregates merge hosts and accounts by default so the stats read as one person's usage. Raw records still retain host and account labels for auditing. Use `--daily-split-hosts` or `--daily-split-accounts` when you want those dimensions separated.
+
+## Sources
+
+| Source | Local data read | Notes |
+|--------|-----------------|-------|
+| Claude Code | `~/.claude/projects/**/*.jsonl`, `~/.claude/transcripts/*.jsonl`, or `ccusage daily --json` | `ccusage` provides cost data when available |
+| Codex | `~/.codex/sessions/**/*.jsonl`, `~/.codex/archived_sessions/*.jsonl` | Uses latest `token_count` event per session |
+| pi | `~/.pi/agent/sessions/**/*.jsonl` | Includes Grok when pi logs `provider=xai-*` and `model=grok-*` |
+| opencode | `~/.local/share/opencode/opencode.db` | Reads session token and cost totals from a temporary SQLite backup |
+
+The `source` column is the app that logged usage. The `service` column is inferred from provider/model names, so Grok used through pi appears as `source=pi` and `service=grok`.
+
+## Offline hosts
+
+Remote collection streams this script over SSH and runs `python3 - --collect-local` on the target. When SSH fails, the script loads `.ai-usage-cache/<host>.json` if it exists and marks those rows with `from_cache=true`.
+
+Hosts with no cache and no successful SSH connection are skipped with a warning.
+
+## Cost semantics
+
+Costs are recorded when the local source reports them:
+
+- Claude Code: from `ccusage` when available.
+- pi: from the session usage object.
+- opencode: from the session table.
+- Codex native session files: token counts are available, but dollar cost is usually not present.
+
+For sources without cost data, `cost_usd` is `0` rather than an estimate.

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -78,8 +78,8 @@ The dashboard is a single file with embedded CSS, aggregate data, and local Java
 - total, input, output, cache, cost, model count, and latest date
 - an All / 7D / 30D / 90D / 1Y / custom date selector plus a host filter defaulting to all hosts
 - D3-rendered daily token flow bars split by input/output/cache/reasoning, with a left token Y axis and log/linear scale toggle
-- an overlaid reported-cost curve on the same D3 date axis, with a right cost Y axis using the same scale mode and hover values anywhere on the plot
-- GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values
+- an overlaid reported-cost curve on the same D3 date axis, with a right cost Y axis using the same scale mode and hover values anywhere on the plot, including provider-by-provider cost for that date
+- GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values including provider-by-provider cost for that date
 - provider mix grouped by model provider family, including Grok usage logged through pi
 - a Tokenmaxxing panel with peak day, average tokens/day, cache multiplier, and output share
 - top models by token volume

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -12,7 +12,7 @@ It keeps a per-host cache, so an offline host does not erase its last known usag
 
 - `python3`
 - `ssh` for remote hosts
-- `ccusage` or `npx` for Claude Code cost data. By default the script tries installed `ccusage`, then `npx --yes ccusage@latest`, then falls back to raw Claude JSONL tokens.
+- `ccusage` or `npx` for unified multi-agent usage and cost data. By default the script tries installed `ccusage`, then `npx --yes ccusage@latest`, and can fall back to local parsers with `--usage-source auto`.
 
 No Python packages are required.
 
@@ -48,8 +48,8 @@ Default outputs:
 # Keep hosts separate in the daily aggregate
 ./ai-usage-collect.py --daily-split-hosts
 
-# Avoid network calls for Claude Code and parse raw JSONL only
-./ai-usage-collect.py --claude-cost-source raw
+# Avoid network calls and use local parsers only
+./ai-usage-collect.py --usage-source local --claude-cost-source raw
 
 # Skip the dashboard when only machine-readable data is needed
 ./ai-usage-collect.py --no-html
@@ -71,9 +71,11 @@ Daily aggregates and the HTML dashboard merge hosts and accounts by default so t
 The dashboard is a single file with embedded CSS, JavaScript, and aggregate data. It shows:
 
 - total, input, output, cache, cost, model count, and latest date
+- an All / 7D / 30D / 90D / 1Y / custom date selector
 - daily token flow bars split by input/output/cache/reasoning
 - reported daily cost line
 - service/source mix, including Grok usage logged through pi
+- a Tokenmaxxing panel with peak day, average tokens/day, cache multiplier, and output share
 - top models by token volume
 - host cache status, including cached/offline hosts
 
@@ -83,12 +85,15 @@ The HTML embeds only aggregate dashboard data, not raw prompts, responses, tool 
 
 | Source | Local data read | Notes |
 |--------|-----------------|-------|
-| Claude Code | `~/.claude/projects/**/*.jsonl`, `~/.claude/transcripts/*.jsonl`, or `ccusage daily --json` | `ccusage` provides cost data when available |
-| Codex | `~/.codex/sessions/**/*.jsonl`, `~/.codex/archived_sessions/*.jsonl` | Uses latest `token_count` event per session |
-| pi | `~/.pi/agent/sessions/**/*.jsonl` | Includes Grok when pi logs `provider=xai-*` and `model=grok-*` |
-| opencode | `~/.local/share/opencode/opencode.db` | Reads session token and cost totals from a temporary SQLite backup |
+| Unified default | `ccusage daily --json --by-agent` | Primary source for all ccusage-supported coding agents and costs |
+| Claude Code fallback | `~/.claude/projects/**/*.jsonl`, `~/.claude/transcripts/*.jsonl`, or `ccusage daily --json` | Used when local mode/fallback is selected |
+| Codex fallback | `~/.codex/sessions/**/*.jsonl`, `~/.codex/archived_sessions/*.jsonl` | Uses latest `token_count` event per session |
+| pi fallback | `~/.pi/agent/sessions/**/*.jsonl` | Includes Grok when pi logs `provider=xai-*` and `model=grok-*` |
+| opencode fallback | `~/.local/share/opencode/opencode.db` | Reads session token and cost totals from a temporary SQLite backup |
 
 The `source` column is the app that logged usage. The `service` column is inferred from provider/model names, so Grok used through pi appears as `source=pi` and `service=grok`.
+
+Use `--usage-source local` to skip ccusage entirely, or `--usage-source auto` to try ccusage first and fall back to local parsers if ccusage returns no rows.
 
 ## Offline hosts
 

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -77,10 +77,10 @@ The dashboard is a single file with embedded CSS, JavaScript, and aggregate data
 
 - total, input, output, cache, cost, model count, and latest date
 - an All / 7D / 30D / 90D / 1Y / custom date selector plus a host filter defaulting to all hosts
-- daily token flow bars split by input/output/cache/reasoning, with a Y axis and log/linear scale toggle
+- daily token flow bars split by input/output/cache/reasoning, with a left token Y axis and log/linear scale toggle
+- an overlaid reported-cost curve on the same date axis, with a right cost Y axis using the same scale mode
 - GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values
-- reported daily cost line
-- service/source mix, including Grok usage logged through pi
+- provider mix grouped by model provider family, including Grok usage logged through pi
 - a Tokenmaxxing panel with peak day, average tokens/day, cache multiplier, and output share
 - top models by token volume
 - host cache status, including cached/offline hosts

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -6,13 +6,13 @@ Collect AI coding-agent usage from local and SSH-reachable machines into JSON, C
 
 Usage lives in ccusage-supported coding-agent history across tools. This script asks ccusage for unified daily usage and normalizes those records without copying prompts, responses, tool arguments, auth files, or raw transcripts.
 
-It keeps a per-host cache, so an offline host does not erase its last known usage.
+Each host's cache is an **append-only ledger**: agents prune their local logs over time (Claude Code deletes old transcripts, reinstalls wipe history), so the collector merges every fresh collection into the cached ledger instead of replacing it. Records that vanish from a host's logs are retained from the ledger; when both sides have the same `(date, source, provider, model)` record, the one with more total tokens wins. An empty collection (for example a host whose ccusage install broke) can never erase history.
 
 ## Requirements
 
 - `python3`
 - `ssh` for remote hosts
-- `ccusage` or `npx` for unified multi-agent usage and cost data. By default the script tries `npx --yes ccusage@latest`, then installed `ccusage`.
+- `ccusage` or `npx` for unified multi-agent usage and cost data. By default the script tries `npx --yes ccusage@latest`, then installed `ccusage`. Pin a version with `--ccusage-package ccusage@<version>`.
 
 No Python packages are required.
 
@@ -31,12 +31,12 @@ Default outputs:
 | `ai-usage-daily.json` | Daily per-model aggregates |
 | `ai-usage-daily.csv` | CSV version of daily aggregates |
 | `ai-usage.html` | Self-contained static dashboard refreshed on each run |
-| `.ai-usage-cache/<host>.json` | Last successful snapshot for each host, stored next to the script by default |
+| `.ai-usage-cache/<host>.json` | Append-only usage ledger for each host, stored next to the script by default |
 
 ## Examples
 
 ```bash
-# Collect this machine plus hosts from ai-usage.hosts next to the script, when present
+# Collect this machine plus all hosts from ai-usage.hosts next to the script, when present
 ./ai-usage-collect.py
 
 # Collect this machine only
@@ -45,8 +45,11 @@ Default outputs:
 # Collect local plus two SSH hosts
 ./ai-usage-collect.py --host eqr5 --host macbook=stone@macbook.local
 
-# Use an inventory file
-./ai-usage-collect.py --inventory ai-usage.hosts
+# Collect hosts one at a time instead of the default 4-way parallel SSH
+./ai-usage-collect.py --parallel 1
+
+# Align daily buckets across machines in different timezones
+./ai-usage-collect.py --timezone Asia/Kolkata
 
 # Keep hosts separate in the daily aggregate
 ./ai-usage-collect.py --daily-split-hosts
@@ -58,7 +61,7 @@ Default outputs:
 ./ai-usage-collect.py --no-html
 ```
 
-When `--inventory` is not provided, the script looks for `ai-usage.hosts` in the same directory as `ai-usage-collect.py`. The local machine is included by default; inventory files are for additional SSH hosts.
+When `--inventory` is not provided, the script looks for `ai-usage.hosts` in the same directory as `ai-usage-collect.py` and collects **every** host listed there. The local machine is included by default; inventory files are for additional SSH hosts. Hosts are collected concurrently (`--parallel`, default 4).
 
 Inventory format:
 
@@ -71,19 +74,34 @@ work-mac stone@work-mac.local account=work
 
 Daily aggregates and the HTML dashboard merge hosts and accounts by default so the stats read as one person's usage. Raw records still retain host and account labels for auditing. Use `--daily-split-hosts` or `--daily-split-accounts` when you want those dimensions separated.
 
+### Duplicate machine detection
+
+Each payload records a stable machine ID (`/etc/machine-id` on Linux, `IOPlatformUUID` on macOS). If two inventory labels resolve to the same physical machine (an alias, an FQDN variant), the second one is skipped with a `duplicate` status so the same usage is never counted twice.
+
+### Push-style collection
+
+Instead of pulling over SSH, each host can push its own ledger on a cron into a synced directory (git repo, Syncthing, NFS):
+
+```bash
+# on each host, e.g. hourly cron
+./ai-usage-collect.py --collect-local --host-label eqr5 --collect-output /synced/ai-usage-cache/eqr5.json
+```
+
+Point the aggregator's `--cache-dir` at that directory. Hosts that are unreachable over SSH fall back to their pushed ledger automatically, so laptops report whenever they are awake instead of needing to be reachable at collection time.
+
 ## HTML dashboard
 
-The dashboard is a single file with embedded CSS, aggregate data, and local JavaScript. The main token/cost chart uses D3 from a CDN for aligned axes and hover interaction. It shows:
+The dashboard is a single self-contained file: CSS, aggregate data, and a pinned D3 build are all inlined, so it works offline (the D3 source is fetched once and cached in the cache directory; if that first fetch fails the file falls back to the CDN). It is responsive down to phone widths. It shows:
 
-- total, input, output, cache, cost, model count, and latest date
-- an All / 7D / 30D / 90D / 1Y / custom date selector plus a host filter defaulting to all hosts
-- D3-rendered daily token flow bars split by input/output/cache/reasoning, with a left token Y axis and log/linear scale toggle
-- an overlaid reported-cost curve on the same D3 date axis, with a right cost Y axis using the same scale mode and hover values anywhere on the plot, including provider-by-provider cost for that date
-- GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values including provider-by-provider cost for that date
-- provider mix grouped by model provider family, including Grok usage logged through pi
+- headline stats led by estimated cost and output tokens (the honest "burn" metrics — raw totals are dominated by cheap cache reads), followed by input, cache, total, model count, and latest date
+- a coverage banner when any host is missing or served from a stale ledger, so incomplete totals are never silent
+- pill-style filters: All / 7D / 30D / 90D / 1Y presets, custom date range, and tap-friendly host chips (multi-select)
+- D3-rendered daily token flow bars split by input/output/cache/reasoning, with a log/linear scale toggle and an overlaid estimated-cost curve with hover values, including provider-by-provider cost per date
+- GitHub-style daily heatmaps for token volume and estimated cost
+- provider mix grouped by inferred model family (Claude, OpenAI, Gemini, Grok, …) regardless of which agent routed the request
 - a Tokenmaxxing panel with peak day, average tokens/day, cache multiplier, and output share
-- top models by token volume
-- host cache status, including cached/offline hosts
+- a sortable, filterable model table (click headers to sort, type to filter by model/provider/agent/host), ranked by estimated cost by default
+- host ledger status, including cached/offline hosts with their last-collected date
 
 The HTML embeds only aggregate dashboard data, not raw prompts, responses, tool calls, or per-session records.
 
@@ -93,15 +111,17 @@ The HTML embeds only aggregate dashboard data, not raw prompts, responses, tool 
 |--------|---------|-------|
 | Unified default | `ccusage daily --json --by-agent` | Primary and only usage source for all ccusage-supported coding agents and costs |
 | Runner selection | `--ccusage-runner auto\|npx\|ccusage` | `auto` prefers `npx ccusage@latest`, then installed `ccusage` |
+| Version pinning | `--ccusage-package ccusage@17.2.0` | npm spec used by the npx runner |
+| Timezone | `--timezone Asia/Kolkata` | Passed to ccusage so daily buckets align across hosts; defaults to each machine's local timezone |
 
-The `source` column is the app that logged usage according to ccusage. The `service` column is inferred from provider/model names, so Grok used through pi appears as `source=pi` and `service=grok`.
+The `source` column is the app that logged usage according to ccusage. The `service` column is inferred from provider/model names, so Grok used through pi appears as `source=pi` and `service=grok`. Reasoning tokens are recorded when ccusage reports them.
 
 ## Offline hosts
 
-Remote collection streams this script over SSH and runs `python3 - --collect-local` on the target. When SSH fails, the script loads `.ai-usage-cache/<host>.json` next to the script by default if it exists and marks those rows with `from_cache=true`.
+Remote collection streams this script over SSH and runs `python3 - --collect-local` on the target. When SSH fails, the script loads the host's ledger from `.ai-usage-cache/<host>.json` and marks those rows with `from_cache=true`; the dashboard flags them in the coverage banner with the ledger's last-collected date.
 
-Hosts with no cache and no successful SSH connection are skipped with a warning.
+Hosts with no ledger and no successful SSH connection are skipped with a warning and surfaced in the coverage banner.
 
 ## Cost semantics
 
-Costs are recorded exactly as reported by `ccusage daily --json --by-agent`. For ccusage-supported rows without cost data, `cost_usd` is `0` rather than an estimate.
+`cost_usd` is ccusage's **API-equivalent estimate** computed from public pricing — useful for trends, but not billed spend (subscription plans make the real number lower). The dashboard labels it "est. cost" throughout. Rows without cost data record `0` rather than an estimate.

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -77,7 +77,7 @@ The dashboard is a single file with embedded CSS, JavaScript, and aggregate data
 
 - total, input, output, cache, cost, model count, and latest date
 - an All / 7D / 30D / 90D / 1Y / custom date selector plus a host filter defaulting to all hosts
-- daily token flow bars split by input/output/cache/reasoning
+- daily token flow bars split by input/output/cache/reasoning, with a Y axis and log/linear scale toggle
 - GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values
 - reported daily cost line
 - service/source mix, including Grok usage logged through pi

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -4,7 +4,7 @@ Collect AI coding-agent usage from local and SSH-reachable machines into JSON, C
 
 ## Why
 
-Usage lives in different places depending on the tool: Claude Code JSONL, Codex session files, pi session files, and opencode SQLite. This script normalizes those records without copying prompts, responses, tool arguments, auth files, or raw transcripts.
+Usage lives in ccusage-supported coding-agent history across tools. This script asks ccusage for unified daily usage and normalizes those records without copying prompts, responses, tool arguments, auth files, or raw transcripts.
 
 It keeps a per-host cache, so an offline host does not erase its last known usage.
 
@@ -12,7 +12,7 @@ It keeps a per-host cache, so an offline host does not erase its last known usag
 
 - `python3`
 - `ssh` for remote hosts
-- `ccusage` or `npx` for unified multi-agent usage and cost data. By default the script tries installed `ccusage`, then `npx --yes ccusage@latest`, and can fall back to local parsers with `--usage-source auto`.
+- `ccusage` or `npx` for unified multi-agent usage and cost data. By default the script tries `npx --yes ccusage@latest`, then installed `ccusage`.
 
 No Python packages are required.
 
@@ -48,8 +48,8 @@ Default outputs:
 # Keep hosts separate in the daily aggregate
 ./ai-usage-collect.py --daily-split-hosts
 
-# Avoid network calls and use local parsers only
-./ai-usage-collect.py --usage-source local --claude-cost-source raw
+# Avoid npx and use an installed ccusage binary only
+./ai-usage-collect.py --ccusage-runner ccusage
 
 # Skip the dashboard when only machine-readable data is needed
 ./ai-usage-collect.py --no-html
@@ -71,8 +71,9 @@ Daily aggregates and the HTML dashboard merge hosts and accounts by default so t
 The dashboard is a single file with embedded CSS, JavaScript, and aggregate data. It shows:
 
 - total, input, output, cache, cost, model count, and latest date
-- an All / 7D / 30D / 90D / 1Y / custom date selector
+- an All / 7D / 30D / 90D / 1Y / custom date selector plus a host filter defaulting to all hosts
 - daily token flow bars split by input/output/cache/reasoning
+- GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values
 - reported daily cost line
 - service/source mix, including Grok usage logged through pi
 - a Tokenmaxxing panel with peak day, average tokens/day, cache multiplier, and output share
@@ -83,17 +84,12 @@ The HTML embeds only aggregate dashboard data, not raw prompts, responses, tool 
 
 ## Sources
 
-| Source | Local data read | Notes |
-|--------|-----------------|-------|
-| Unified default | `ccusage daily --json --by-agent` | Primary source for all ccusage-supported coding agents and costs |
-| Claude Code fallback | `~/.claude/projects/**/*.jsonl`, `~/.claude/transcripts/*.jsonl`, or `ccusage daily --json` | Used when local mode/fallback is selected |
-| Codex fallback | `~/.codex/sessions/**/*.jsonl`, `~/.codex/archived_sessions/*.jsonl` | Uses latest `token_count` event per session |
-| pi fallback | `~/.pi/agent/sessions/**/*.jsonl` | Includes Grok when pi logs `provider=xai-*` and `model=grok-*` |
-| opencode fallback | `~/.local/share/opencode/opencode.db` | Reads session token and cost totals from a temporary SQLite backup |
+| Source | Command | Notes |
+|--------|---------|-------|
+| Unified default | `ccusage daily --json --by-agent` | Primary and only usage source for all ccusage-supported coding agents and costs |
+| Runner selection | `--ccusage-runner auto\|npx\|ccusage` | `auto` prefers `npx ccusage@latest`, then installed `ccusage` |
 
-The `source` column is the app that logged usage. The `service` column is inferred from provider/model names, so Grok used through pi appears as `source=pi` and `service=grok`.
-
-Use `--usage-source local` to skip ccusage entirely, or `--usage-source auto` to try ccusage first and fall back to local parsers if ccusage returns no rows.
+The `source` column is the app that logged usage according to ccusage. The `service` column is inferred from provider/model names, so Grok used through pi appears as `source=pi` and `service=grok`.
 
 ## Offline hosts
 
@@ -103,11 +99,4 @@ Hosts with no cache and no successful SSH connection are skipped with a warning.
 
 ## Cost semantics
 
-Costs are recorded when the local source reports them:
-
-- Claude Code: from `ccusage` when available.
-- pi: from the session usage object.
-- opencode: from the session table.
-- Codex native session files: token counts are available, but dollar cost is usually not present.
-
-For sources without cost data, `cost_usd` is `0` rather than an estimate.
+Costs are recorded exactly as reported by `ccusage daily --json --by-agent`. For ccusage-supported rows without cost data, `cost_usd` is `0` rather than an estimate.

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -73,12 +73,12 @@ Daily aggregates and the HTML dashboard merge hosts and accounts by default so t
 
 ## HTML dashboard
 
-The dashboard is a single file with embedded CSS, JavaScript, and aggregate data. It shows:
+The dashboard is a single file with embedded CSS, aggregate data, and local JavaScript. The main token/cost chart uses D3 from a CDN for aligned axes and hover interaction. It shows:
 
 - total, input, output, cache, cost, model count, and latest date
 - an All / 7D / 30D / 90D / 1Y / custom date selector plus a host filter defaulting to all hosts
-- daily token flow bars split by input/output/cache/reasoning, with a left token Y axis and log/linear scale toggle
-- an overlaid reported-cost curve on the same date axis, with a right cost Y axis using the same scale mode
+- D3-rendered daily token flow bars split by input/output/cache/reasoning, with a left token Y axis and log/linear scale toggle
+- an overlaid reported-cost curve on the same D3 date axis, with a right cost Y axis using the same scale mode and hover values anywhere on the plot
 - GitHub-style daily heatmaps for token volume and reported cost, with month markers and hover values
 - provider mix grouped by model provider family, including Grok usage logged through pi
 - a Tokenmaxxing panel with peak day, average tokens/day, cache multiplier, and output share

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -31,13 +31,16 @@ Default outputs:
 | `ai-usage-daily.json` | Daily per-model aggregates |
 | `ai-usage-daily.csv` | CSV version of daily aggregates |
 | `ai-usage.html` | Self-contained static dashboard refreshed on each run |
-| `.ai-usage-cache/<host>.json` | Last successful snapshot for each host |
+| `.ai-usage-cache/<host>.json` | Last successful snapshot for each host, stored next to the script by default |
 
 ## Examples
 
 ```bash
-# Collect this machine only
+# Collect this machine plus hosts from ai-usage.hosts next to the script, when present
 ./ai-usage-collect.py
+
+# Collect this machine only
+./ai-usage-collect.py --inventory /dev/null
 
 # Collect local plus two SSH hosts
 ./ai-usage-collect.py --host eqr5 --host macbook=stone@macbook.local
@@ -54,6 +57,8 @@ Default outputs:
 # Skip the dashboard when only machine-readable data is needed
 ./ai-usage-collect.py --no-html
 ```
+
+When `--inventory` is not provided, the script looks for `ai-usage.hosts` in the same directory as `ai-usage-collect.py`. The local machine is included by default; inventory files are for additional SSH hosts.
 
 Inventory format:
 
@@ -93,7 +98,7 @@ The `source` column is the app that logged usage according to ccusage. The `serv
 
 ## Offline hosts
 
-Remote collection streams this script over SSH and runs `python3 - --collect-local` on the target. When SSH fails, the script loads `.ai-usage-cache/<host>.json` if it exists and marks those rows with `from_cache=true`.
+Remote collection streams this script over SSH and runs `python3 - --collect-local` on the target. When SSH fails, the script loads `.ai-usage-cache/<host>.json` next to the script by default if it exists and marks those rows with `from_cache=true`.
 
 Hosts with no cache and no successful SSH connection are skipped with a warning.
 

--- a/docs/ai-usage-collect.md
+++ b/docs/ai-usage-collect.md
@@ -1,6 +1,6 @@
 # ai-usage-collect.py
 
-Collect AI coding-agent usage from local and SSH-reachable machines into JSON and CSV files.
+Collect AI coding-agent usage from local and SSH-reachable machines into JSON, CSV, and a static HTML dashboard.
 
 ## Why
 
@@ -30,6 +30,7 @@ Default outputs:
 | `ai-usage.csv` | CSV version of raw records |
 | `ai-usage-daily.json` | Daily per-model aggregates |
 | `ai-usage-daily.csv` | CSV version of daily aggregates |
+| `ai-usage.html` | Self-contained static dashboard refreshed on each run |
 | `.ai-usage-cache/<host>.json` | Last successful snapshot for each host |
 
 ## Examples
@@ -49,6 +50,9 @@ Default outputs:
 
 # Avoid network calls for Claude Code and parse raw JSONL only
 ./ai-usage-collect.py --claude-cost-source raw
+
+# Skip the dashboard when only machine-readable data is needed
+./ai-usage-collect.py --no-html
 ```
 
 Inventory format:
@@ -60,7 +64,20 @@ eqr5 stone@eqr5.local account=personal
 work-mac stone@work-mac.local account=work
 ```
 
-Daily aggregates merge hosts and accounts by default so the stats read as one person's usage. Raw records still retain host and account labels for auditing. Use `--daily-split-hosts` or `--daily-split-accounts` when you want those dimensions separated.
+Daily aggregates and the HTML dashboard merge hosts and accounts by default so the stats read as one person's usage. Raw records still retain host and account labels for auditing. Use `--daily-split-hosts` or `--daily-split-accounts` when you want those dimensions separated.
+
+## HTML dashboard
+
+The dashboard is a single file with embedded CSS, JavaScript, and aggregate data. It shows:
+
+- total, input, output, cache, cost, model count, and latest date
+- daily token flow bars split by input/output/cache/reasoning
+- reported daily cost line
+- service/source mix, including Grok usage logged through pi
+- top models by token volume
+- host cache status, including cached/offline hosts
+
+The HTML embeds only aggregate dashboard data, not raw prompts, responses, tool calls, or per-session records.
 
 ## Sources
 

--- a/docs/env-diff.md
+++ b/docs/env-diff.md
@@ -1,0 +1,64 @@
+# env-diff.sh
+
+Compare two `.env` files and render a readable diff table with [`gum`](https://github.com/charmbracelet/gum).
+
+## Why
+
+Environment files often contain repeated keys, local overrides, and secrets. This script shows what changed without dumping token-like values into terminal scrollback or logs.
+
+## Requirements
+
+- `bash`
+- `awk`
+- `sort`
+- `gum`
+
+## Usage
+
+```bash
+./env-diff.sh [OPTIONS] LEFT_ENV RIGHT_ENV
+```
+
+Options:
+
+| Option | Description |
+|--------|-------------|
+| `-a`, `--all` | Include unchanged variables in the table |
+| `--exit-code` | Exit `1` when differences are found |
+| `--max-width WIDTH` | Limit displayed width for non-secret values, default `80` |
+| `-h`, `--help` | Show help text |
+
+## Examples
+
+```bash
+# Show only differences
+./env-diff.sh .env .env.example
+
+# Include unchanged variables too
+./env-diff.sh --all .env.local .env.production
+
+# Use in a check script
+./env-diff.sh --exit-code .env.old .env.new
+```
+
+## Diff semantics
+
+- Blank lines and comments are ignored.
+- `export NAME=value` is accepted.
+- Duplicate assignments in the same file use the last value encountered.
+- Variables only in the right file are shown as `ADDED`.
+- Variables only in the left file are shown as `REMOVED`.
+- Variables in both files with different final values are shown as `CHANGED`.
+
+## Secret redaction
+
+Values are redacted when the variable name or value looks sensitive, including names containing `TOKEN`, `SECRET`, `PASSWORD`, `KEY`, credentials, auth/session/cookie fields, private-key blocks, common provider token prefixes, JWT-like values, long hex strings, and long high-entropy token-like strings.
+
+Redacted values are displayed with per-run labels such as:
+
+```text
+<redacted #1 len=42>
+<redacted #2 len=42>
+```
+
+The labels preserve equality/difference information without printing the secret itself.

--- a/env-diff.sh
+++ b/env-diff.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+#
+# env-diff.sh - Compare two .env files without leaking token-like values.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+MAX_VALUE_WIDTH=80
+ENV_DIFF_TEMP_DIR=""
+
+show_help() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] LEFT_ENV RIGHT_ENV
+
+Compare two .env files and render the result as a gum table. Duplicate
+assignments inside one file use the last value, matching dotenv override style.
+
+OPTIONS:
+    -h, --help              Show this help message
+    -a, --all               Include unchanged variables in the table
+    --exit-code             Exit 1 when differences are found
+    --max-width WIDTH       Maximum displayed width for non-secret values
+
+NOTES:
+    Values that look like tokens, passwords, credentials, or private keys are
+    redacted. Redacted values get stable per-run labels so equality and
+    differences are still visible without printing the secret itself.
+
+EXAMPLES:
+    $(basename "$0") .env .env.example
+    $(basename "$0") --all .env.local .env.production
+    $(basename "$0") --exit-code .env.old .env.new
+EOF
+}
+
+error() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+require_command() {
+    local command_name="$1"
+
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        error "'$command_name' is required but not installed"
+    fi
+}
+
+cleanup() {
+    if [[ -n "${ENV_DIFF_TEMP_DIR:-}" ]]; then
+        rm -rf "$ENV_DIFF_TEMP_DIR"
+    fi
+}
+
+parse_env_file() {
+    local input_file="$1"
+    local output_file="$2"
+
+    awk '
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        function unescape_double_quoted(value) {
+            gsub(/\\\\/, "\\", value)
+            gsub(/\\"/, "\"", value)
+            gsub(/\\n/, "\n", value)
+            gsub(/\\r/, "\r", value)
+            gsub(/\\t/, "\t", value)
+            return value
+        }
+
+        function parse_value(value, quote) {
+            value = trim(value)
+
+            if (length(value) >= 2) {
+                quote = substr(value, 1, 1)
+                if (quote == "\"" || quote == "'\''") {
+                    value = substr(value, 2)
+                    if (index(value, quote) > 0) {
+                        value = substr(value, 1, index(value, quote) - 1)
+                    }
+                    if (quote == "\"") {
+                        value = unescape_double_quoted(value)
+                    }
+                    return value
+                }
+            }
+
+            sub(/[[:space:]]+#.*$/, "", value)
+            return trim(value)
+        }
+
+        {
+            line = $0
+            sub(/\r$/, "", line)
+
+            if (line ~ /^[[:space:]]*($|#)/) {
+                next
+            }
+
+            sub(/^[[:space:]]*export[[:space:]]+/, "", line)
+            equals_index = index(line, "=")
+            if (equals_index == 0) {
+                next
+            }
+
+            key = trim(substr(line, 1, equals_index - 1))
+            if (key !~ /^[A-Za-z_][A-Za-z0-9_]*$/) {
+                next
+            }
+
+            value = parse_value(substr(line, equals_index + 1))
+            gsub(/\r/, "\\r", value)
+            gsub(/\n/, "\\n", value)
+            gsub(/\t/, "\\t", value)
+
+            if (!(key in seen)) {
+                keys[++key_count] = key
+                seen[key] = 1
+            }
+            values[key] = value
+        }
+
+        END {
+            for (idx = 1; idx <= key_count; idx++) {
+                key = keys[idx]
+                printf "%s\t%s\n", key, values[key]
+            }
+        }
+    ' "$input_file" > "$output_file"
+}
+
+generate_rows() {
+    local left_parsed="$1"
+    local right_parsed="$2"
+
+    awk -v max_width="$MAX_VALUE_WIDTH" '
+        BEGIN {
+            FS = OFS = "\t"
+        }
+
+        function has_alpha(value) {
+            return value ~ /[[:alpha:]]/
+        }
+
+        function has_digit(value) {
+            return value ~ /[[:digit:]]/
+        }
+
+        function has_symbol(value) {
+            return value ~ /[^[:alnum:]_]/
+        }
+
+        function is_sensitive_key(key, lowered) {
+            lowered = tolower(key)
+            return lowered ~ /(^|_)(api[_-]?)?key($|_)|secret|token|password|passwd|pwd|credential|private|bearer|auth|session|cookie|client_secret|access_key|refresh/
+        }
+
+        function looks_like_token(value) {
+            if (value == "") {
+                return 0
+            }
+
+            if (value ~ /^-----BEGIN [A-Z ]*PRIVATE KEY-----/) {
+                return 1
+            }
+            if (value ~ /^(gh[pousr]_|github_pat_|glpat-|sk-[A-Za-z0-9]|xox[baprs]-|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|ya29\.|eyJ[A-Za-z0-9_-]*\.)/) {
+                return 1
+            }
+            if (value ~ /(token|secret|signature|sig|apikey|api_key|access_key|client_secret)=/) {
+                return 1
+            }
+            if (value ~ /^[A-Fa-f0-9]{32,}$/) {
+                return 1
+            }
+            if (length(value) >= 24 && value !~ /[[:space:]]/ && value ~ /^[A-Za-z0-9_+\/.=:-]+$/ && has_alpha(value) && has_digit(value) && (has_symbol(value) || length(value) >= 32)) {
+                return 1
+            }
+
+            return 0
+        }
+
+        function redacted_value(value) {
+            if (value == "") {
+                return "∅"
+            }
+            if (!(value in secret_ids)) {
+                secret_ids[value] = ++secret_count
+            }
+            return "<redacted #" secret_ids[value] " len=" length(value) ">"
+        }
+
+        function display_value(key, value, shown) {
+            if (value == "") {
+                return "∅"
+            }
+            if (is_sensitive_key(key) || looks_like_token(value)) {
+                return redacted_value(value)
+            }
+
+            shown = value
+            gsub(/\r/, "\\r", shown)
+            gsub(/\n/, "\\n", shown)
+            if (length(shown) > max_width) {
+                shown = substr(shown, 1, max_width - 1) "…"
+            }
+            return shown
+        }
+
+        NR == FNR {
+            left[$1] = $2
+            if (!($1 in seen)) {
+                keys[++key_count] = $1
+                seen[$1] = 1
+            }
+            next
+        }
+
+        {
+            right[$1] = $2
+            if (!($1 in seen)) {
+                keys[++key_count] = $1
+                seen[$1] = 1
+            }
+        }
+
+        END {
+            for (idx = 1; idx <= key_count; idx++) {
+                key = keys[idx]
+                has_left = key in left
+                has_right = key in right
+
+                if (has_left && has_right) {
+                    if (left[key] == right[key]) {
+                        status = "SAME"
+                    } else {
+                        status = "CHANGED"
+                    }
+                } else if (has_right) {
+                    status = "ADDED"
+                } else {
+                    status = "REMOVED"
+                }
+
+                left_display = has_left ? display_value(key, left[key]) : "—"
+                right_display = has_right ? display_value(key, right[key]) : "—"
+                print status, key, left_display, right_display
+            }
+        }
+    ' "$left_parsed" "$right_parsed"
+}
+
+print_table() {
+    local rows_file="$1"
+    local left_label="$2"
+    local right_label="$3"
+    local left_name
+    local right_name
+
+    left_name=$(basename "$left_label")
+    right_name=$(basename "$right_label")
+
+    gum style \
+        --foreground 212 \
+        --border-foreground 212 \
+        --border rounded \
+        --align center \
+        --width 72 \
+        --margin "1 0" \
+        --padding "1 2" \
+        "Environment Diff" \
+        "$left_name → $right_name"
+
+    if [[ ! -s "$rows_file" ]]; then
+        gum style --foreground 42 "No differences found."
+        return
+    fi
+
+    gum table \
+        --print \
+        --separator $'\t' \
+        --columns "Status,Env Var,Left,Right" \
+        --widths "10,30,${MAX_VALUE_WIDTH},${MAX_VALUE_WIDTH}" \
+        --border rounded \
+        --header.foreground 212 \
+        --border.foreground 240 \
+        --file "$rows_file"
+}
+
+main() {
+    local show_all=false
+    local use_exit_code=false
+    local left_file=""
+    local right_file=""
+    local left_parsed
+    local right_parsed
+    local all_rows
+    local display_rows
+    local total_count
+    local changed_count
+    local added_count
+    local removed_count
+    local same_count
+    local positional=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            -a|--all)
+                show_all=true
+                shift
+                ;;
+            --exit-code)
+                use_exit_code=true
+                shift
+                ;;
+            --max-width)
+                [[ $# -ge 2 ]] || error "Missing value for $1"
+                [[ "$2" =~ ^[0-9]+$ ]] || error "--max-width must be a positive integer"
+                (( 2 <= 10#$2 )) || error "--max-width must be at least 2"
+                MAX_VALUE_WIDTH="$2"
+                shift 2
+                ;;
+            --)
+                shift
+                while [[ $# -gt 0 ]]; do
+                    positional+=("$1")
+                    shift
+                done
+                ;;
+            -* )
+                error "Unknown option: $1. Use -h or --help for usage information."
+                ;;
+            *)
+                positional+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ ${#positional[@]} -eq 2 ]] || error "Expected LEFT_ENV and RIGHT_ENV. Use -h or --help for usage information."
+    left_file="${positional[0]}"
+    right_file="${positional[1]}"
+
+    [[ -f "$left_file" ]] || error "File not found: $left_file"
+    [[ -f "$right_file" ]] || error "File not found: $right_file"
+
+    require_command gum
+    require_command awk
+    require_command sort
+
+    ENV_DIFF_TEMP_DIR=$(mktemp -d)
+    trap cleanup EXIT
+
+    left_parsed="$ENV_DIFF_TEMP_DIR/left.tsv"
+    right_parsed="$ENV_DIFF_TEMP_DIR/right.tsv"
+    all_rows="$ENV_DIFF_TEMP_DIR/all.tsv"
+    display_rows="$ENV_DIFF_TEMP_DIR/display.tsv"
+
+    parse_env_file "$left_file" "$left_parsed"
+    parse_env_file "$right_file" "$right_parsed"
+    generate_rows "$left_parsed" "$right_parsed" | sort -t $'\t' -k2,2f > "$all_rows"
+
+    if [[ "$show_all" == true ]]; then
+        cp "$all_rows" "$display_rows"
+    else
+        awk -F $'\t' '$1 != "SAME"' "$all_rows" > "$display_rows"
+    fi
+
+    total_count=$(awk -F $'\t' '$1 != "SAME" { count++ } END { print count + 0 }' "$all_rows")
+    changed_count=$(awk -F $'\t' '$1 == "CHANGED" { count++ } END { print count + 0 }' "$all_rows")
+    added_count=$(awk -F $'\t' '$1 == "ADDED" { count++ } END { print count + 0 }' "$all_rows")
+    removed_count=$(awk -F $'\t' '$1 == "REMOVED" { count++ } END { print count + 0 }' "$all_rows")
+    same_count=$(awk -F $'\t' '$1 == "SAME" { count++ } END { print count + 0 }' "$all_rows")
+
+    print_table "$display_rows" "$left_file" "$right_file"
+
+    gum style \
+        --foreground 244 \
+        "Summary: $total_count differences ($changed_count changed, $added_count added, $removed_count removed), $same_count unchanged."
+
+    if [[ "$use_exit_code" == true && "$total_count" -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
## Summary
- add env-diff.sh for comparing dotenv files with token-like value redaction
- add ai-usage-collect.py to collect ccusage-backed Claude Code, Codex, pi, opencode, Gemini, Grok-through-pi, and other ccusage-supported usage from local/SSH hosts
- use ccusage only for usage collection, preferring npx ccusage@latest by default and preserving per-host caches beside the script for offline hosts
- support an ignored ai-usage.hosts inventory next to the script; no-arg runs include local plus all inventory hosts from any working directory
- write raw plus daily JSON/CSV stats and generate a self-contained ai-usage.html dashboard on each run
- add dashboard date presets/custom range, multi-select host filtering, D3-rendered daily token bars and cost curve on one shared X axis, left token Y axis, right cost Y axis, log/linear scale toggle, hover values anywhere on the graph with provider-by-provider cost for the selected date, daily token/cost heatmaps with month markers and provider cost hovers, provider mix, cleaned model names, top models with explicit host names, tokenmaxxing metrics, and host cache status
- ignore generated usage artifacts and document usage/requirements in README and docs

## Tests
- claude -p --model fable --effort medium used for dashboard implementation guidance
- npx --yes ccusage@latest --help and unified ccusage JSON shape inspected
- shellcheck env-diff.sh
- git diff --check
- python3 -m py_compile ai-usage-collect.py ccusage.py check-pr.py
- ./ai-usage-collect.py --help
- full default inventory ccusage run for local MacBook, eqr5, t14, 1990-dev, stone-node, proxmox; x13 timed out and cache handling stayed intact
- no-args inventory smoke run from another directory verified script-side inventory lookup
- audit verified embedded dashboard rows equal raw/daily totals for input, output, cache creation, cache read, reasoning, total tokens, and cost
- audit verified per-day provider cost subtotals match daily reported cost
- audit verified provider grouping, D3 chart markers, shared token/cost chart path, hover layer, host filter math, >30 dates, Grok aggregate, cleaned pi model names, heatmap month markers, and Tokenmaxxing dashboard