### PR TITLE
feat(gitx): add git workflow dispatcher, rework check-pr

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,11 @@
 # Claude Development Context
 
 ## Repository Purpose
+
 Personal utility scripts for automation and file processing tasks. Scripts range from simple one-liners to comprehensive bash utilities for tasks like format conversion, file manipulation, and system automation.
 
 ## Development Guidelines
+
 - **Language**: Bash for shell scripts with portability focus
 - **Quality**: All scripts must pass shellcheck validation
 - **Dependencies**: Document external tool requirements (ffmpeg, gum, etc.)
@@ -11,12 +13,14 @@ Personal utility scripts for automation and file processing tasks. Scripts range
 - **Compatibility**: Cross-platform support, especially filename handling (FAT32, etc.)
 
 ## Script Requirements
+
 - Executable permissions, proper shebang, and clean structure
 - Command-line parsing with help options (-h/--help)
 - Input validation, dependency checking, and error handling
 - Progress indicators for long-running operations
 
 ## Coding Style & Preferences
+
 - **Filenames**: Descriptive names with hyphens (`audiobook-split.sh`)
 - **Output naming**: Use directory name as file prefix when custom output specified
 - **Numbering**: Dynamic digits based on count (2 for <100, 3 for <1000), start from 1
@@ -26,6 +30,7 @@ Personal utility scripts for automation and file processing tasks. Scripts range
 - **UI**: Optional prompts only with defaults, not explicit user values
 
 ## Development Rules
+
 - **Never commit to main branch**
 - **Never use pkill on generic processes like `python3`**
 - **Always update README when changing scripts**
@@ -35,7 +40,9 @@ Personal utility scripts for automation and file processing tasks. Scripts range
 ## Development Log
 
 ### Audiobook Pipeline Enhancement (2025-07-09)
+
 Enhanced audiobook-pipeline.sh with modular design and smart automation:
+
 - **Auto-conversion**: Fixed file detection using before/after comparison
 - **Help system**: Added `-h/--help` for all subcommands
 - **Modular commands**: Separated download, convert, split, and automate workflows
@@ -43,9 +50,11 @@ Enhanced audiobook-pipeline.sh with modular design and smart automation:
 - **Multi-tier fallback**: ASIN → title → word-based file detection
 
 ### Power Monitor System Development (2025-07-11 to 2025-07-13)
+
 Complete power monitoring system for house/room-level status tracking:
 
 **Core Features**:
+
 - **Backup-aware logic**: Differentiates main vs backup power switches
 - **MAC validation**: Prevents IP conflict false positives via ARP table
 - **Three-stage detection**: Ping → ARP check → ARP refresh fallback
@@ -53,6 +62,7 @@ Complete power monitoring system for house/room-level status tracking:
 - **Modular design**: Separated lib/ modules (database, network, power-logic, config, ui)
 
 **Key Fixes**:
+
 - **ARP false positives**: Enhanced freshness validation (REACHABLE/DELAY vs STALE)
 - **Detection method tracking**: Numeric codes (0=FAILED, 1=PING_ONLY, 2=PING_MAC, 3=ARP_FRESH, etc.)
 - **Uptime calculation**: Fixed to track actual state changes, not latest record time
@@ -62,21 +72,62 @@ Complete power monitoring system for house/room-level status tracking:
 **Power States**: ONLINE (green), BACKUP (yellow), CRITICAL/OFFLINE (red)
 **Monitoring**: Real-time status, historical analysis, automated cron deployment
 
+### gitx Dispatcher and check-pr Rework (2026-07-25)
+
+Wrapped the git tooling behind `gitx.sh` (dispatcher + `gitx/lib/` modules, following
+power-monitor's layout) and reworked `check-pr.py`.
+
+**gitx commands**: `status`, `changed`, `branch`, `sync`, `cleanup`, plus `pr` and
+`gitignore` delegating to `check-pr.sh` and `gi-select.sh`.
+
+**Key decisions**:
+
+- **Merge-base diffs**: `changed` uses `git diff <merge-base>` so commits landing on the
+  default branch afterwards are not attributed to the branch
+- **Squash-merge detection**: replay the branch tree as one commit on the merge base, then
+  `git cherry` against the default branch. `git branch --merged` cannot see these
+- **Checkout-free sync**: `git fetch origin main:main` fast-forwards the default branch
+  from a feature branch; a diverged local branch is reported, never forced
+- **Default branch detection**: remote `HEAD` symref first, then `main`/`master`/`trunk`/
+  `develop` on the remote, then locally. No network in read-only commands
+- **fzf vs gum**: fzf for pickers with previews, gum for prompts/spinners/multi-select.
+  Pickers gate on a usable `/dev/tty`, not `-t 1`, so `-i --name-only | xargs` still works
+- **Dry run default**: `cleanup` requires `--apply`; `-d` for merged, `-D` only for
+  squash-merged
+
+**check-pr fixes**:
+
+- **Sorting**: checks ordered failing → pending → other → skipped → passing, alphabetical
+  within a state, so rows stop shuffling between refreshes
+- **Short terminals**: split fetching (`collect_state`) from rendering (`render_state`) so
+  watch mode re-renders each tick at the current size, drops passing checks when too tall,
+  then truncates with a marker. Rich's `Live` was silently cropping the bottom
+- **Previous run column**: `Previous` (verdict + duration) and `Trend`
+  (regressed/fixed/still failing/slower N×/running long N×). Regressions and overruns are
+  promoted into "Needs attention"
+- **Previous-duration bug**: baselines came from cancelled runs, so several jobs all
+  reported the cancellation timestamp (identical bogus values). Cancelled runs are now
+  excluded
+- **Review bug**: a COMMENTED review overwrote that user's earlier APPROVED; only
+  APPROVED/CHANGES_REQUESTED/DISMISSED are decisive now
+- **API calls**: job details came one `gh api` call per check. Run ids are already in the
+  check link, so jobs are fetched per _run_ instead: 24 checks over 12 runs went from ~37
+  calls to 18, and the branch run-history fetch now overlaps the job listings
+
 ### Locale Configuration Script (2025-08-15)
+
 Created set-locale.sh for comprehensive locale management:
 
 **Core Features**:
-- **Automatic Setup**: Generates and configures en_US.UTF-8 locale with all LC_* variables
+
+- **Automatic Setup**: Generates and configures `en_US.UTF-8` locale with all `LC_*` variables
 - **System Integration**: Updates /etc/default/locale and current session without restart
 - **Cleanup Option**: Removes unused locales (--cleanup) keeping only en_US.UTF-8 and C/POSIX
 - **Verification**: Complete locale status checking (--verify) with detailed output
 
 **Key Components**:
+
 - **Safety First**: Backup creation before cleanup, confirmation prompts for destructive actions
 - **Cross-platform**: Works with different locale-gen implementations and system configurations
 - **Immediate Effect**: Updates current session environment variables for instant usage
 - **Space Optimization**: Cleans both locale.gen and locale archive to minimize disk usage
-
-
-
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ power-monitor's layout) and reworked `check-pr.py`.
   excluded
 - **Review bug**: a COMMENTED review overwrote that user's earlier APPROVED; only
   APPROVED/CHANGES_REQUESTED/DISMISSED are decisive now
+- **Watch keybindings**: `r` refreshes now, `q` quits, via cbreak mode on stdin (skipped
+  when stdin is not a tty, so cron and pipes are unaffected). Refresh spam is contained
+  two ways: a 3s cooldown on manual refreshes, and discarding keys buffered during a fetch
+  (a queued keypress would otherwise become one API burst per press). `q` is still honored
+  from that buffer, since a fetch can take seconds
 - **API calls**: job details came one `gh api` call per check. Run ids are already in the
   check link, so jobs are fetched per _run_ instead: 24 checks over 12 runs went from ~37
   calls to 18, and the branch run-history fetch now overlaps the job listings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,8 @@ Complete power monitoring system for house/room-level status tracking:
 Wrapped the git tooling behind `gitx.sh` (dispatcher + `gitx/lib/` modules, following
 power-monitor's layout) and reworked `check-pr.py`.
 
-**gitx commands**: `status`, `changed`, `branch`, `sync`, `cleanup`, plus `pr` and
-`gitignore` delegating to `check-pr.sh` and `gi-select.sh`.
+**gitx commands**: `status`, `changed`, `branch`, `sync`, `cleanup`, `pr check`, `pr list`,
+and `gitignore`. `pr check` and `gitignore` delegate to `check-pr.sh` and `gi-select.sh`.
 
 **Key decisions**:
 
@@ -96,7 +96,12 @@ power-monitor's layout) and reworked `check-pr.py`.
   remote falls back to a guess and says so
 - **Deploy branch vs default branch**: `status --vs REF` (repeatable, or
   `GITX_STATUS_COMPARE`) adds Compare rows, for repos like merrilin where `development` is
-  default and `main` is what ships
+  default and `main` is what ships. `pr list` flags PRs whose destination is not the default
+  branch for the same reason
+- **`gitx_spin` and captured output**: the fallback path printed its progress line to
+  stdout, which corrupted `$(...)` captures (`pr list` fed it to jq). Progress now goes to
+  stderr, and the gum path uses `--show-output` so the wrapped command's stdout passes
+  through. Verified under a pty that the spinner itself never leaks into stdout
 - **fzf vs gum**: fzf for pickers with previews, gum for prompts/spinners/multi-select.
   Pickers gate on a usable `/dev/tty`, not `-t 1`, so `-i --name-only | xargs` still works
 - **Dry run default**: `cleanup` requires `--apply`; `-d` for merged, `-D` only for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,15 @@ power-monitor's layout) and reworked `check-pr.py`.
   `git cherry` against the default branch. `git branch --merged` cannot see these
 - **Checkout-free sync**: `git fetch origin main:main` fast-forwards the default branch
   from a feature branch; a diverged local branch is reported, never forced
-- **Default branch detection**: remote `HEAD` symref first, then `main`/`master`/`trunk`/
-  `develop` on the remote, then locally. No network in read-only commands
+- **Default branch detection**: remote `HEAD` symref first. When it is missing, guessing
+  from a name list is only safe if exactly one candidate exists — a repo whose default is
+  `development` but which also has `main` (merrilin) would otherwise resolve to `main`. On
+  ambiguity, ask via `git ls-remote --symref` and cache the answer into
+  `refs/remotes/<remote>/HEAD`, so the network cost happens at most once. An unreachable
+  remote falls back to a guess and says so
+- **Deploy branch vs default branch**: `status --vs REF` (repeatable, or
+  `GITX_STATUS_COMPARE`) adds Compare rows, for repos like merrilin where `development` is
+  default and `main` is what ships
 - **fzf vs gum**: fzf for pickers with previews, gum for prompts/spinners/multi-select.
   Pickers gate on a usable `/dev/tty`, not `-t 1`, so `-i --name-only | xargs` still works
 - **Dry run default**: `cleanup` requires `--apply`; `-d` for merged, `-D` only for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,12 @@ power-monitor's layout) and reworked `check-pr.py`.
   excluded
 - **Review bug**: a COMMENTED review overwrote that user's earlier APPROVED; only
   APPROVED/CHANGES_REQUESTED/DISMISSED are decisive now
+- **Idle repaints**: `Live(refresh_per_second=4)` with auto-refresh repainted the whole
+  region 4x/second even when nothing changed, which is what made a refresh look like a full
+  redraw. Now `auto_refresh=False`, the body is rebuilt only when its inputs change
+  (revision/size/concise), and a frame is painted only when it differs from what is on
+  screen: 4 frames/s -> 1.1 (the countdown), 72% less terminal output while idle. Textual
+  is not needed for this; it would only buy per-cell updates
 - **Watch keybindings**: `r` refreshes now, `q` quits, via cbreak mode on stdin (skipped
   when stdin is not a tty, so cron and pipes are unaffected). Refresh spam is contained
   two ways: a 3s cooldown on manual refreshes, and discarding keys buffered during a fetch

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, checks sorted worst-first, runner/machine info, previous-run verdict and timing trend (regressed/fixed/slower), reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
-- **[gitx.sh](docs/gitx.md)** - Git workflow dispatcher: branch status, merge-base changed files with +/- counts, conventional branch creation, checkout-free default-branch sync, squash-merge-aware branch cleanup, and wrappers for check-pr and gi-select
+- **[gitx.sh](docs/gitx.md)** - Git workflow dispatcher: branch status, merge-base changed files with +/- counts, conventional branch creation, checkout-free default-branch sync, squash-merge-aware branch cleanup, a PR listing with author and destination branch, and wrappers for check-pr and gi-select
 - **[highlight-manager.sh](docs/highlight-manager.md)** - Manage Kindle highlights with DuckDB storage and beautiful terminal display
 
 ### Notifications
@@ -66,7 +66,9 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 ./gitx.sh sync --rebase  # Fetch, fast-forward main, rebase the current branch
 ./gitx.sh cleanup  # List merged and squash-merged branches (dry run)
 ./gitx.sh cleanup --apply  # Delete them after a gum confirmation
-./gitx.sh pr --concise  # Wraps check-pr.sh
+./gitx.sh pr check --concise  # Wraps check-pr.sh
+./gitx.sh pr list  # Open PRs with author and destination branch, off-target ones flagged
+./gitx.sh pr list --base main --mine  # Filter by destination branch and author
 
 # Collect AI coding-agent usage into JSON/CSV stats, ai-usage.html, and a shareable infographic
 ./ai-usage.sh
@@ -111,7 +113,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 | check-pr           | `uv`, `gh`, `git`                                                                                              |
 | env-diff           | `gum`, `awk`, `sort`                                                                                           |
 | gi-select          | `gum`, gitignore repository                                                                                    |
-| gitx               | `git`; `fzf` and `gum` for pickers and prompts; `uv` + `gh` for `gitx pr`                                      |
+| gitx               | `git`; `fzf` and `gum` for pickers and prompts; `uv` + `gh` for `pr check`; `gh` + `jq` for `pr list`          |
 | highlight-manager  | `duckdb`, `gum`, `jq`, `python3`                                                                               |
 | ntfy               | `curl`                                                                                                         |
 | simple-notify      | `curl`                                                                                                         |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 
 # Check status of open PR for current branch
 ./check-pr.sh  # Show one-line merge status plus checks and bot reviews
-./check-pr.sh -w  # Watch mode, refresh every 30 seconds
+./check-pr.sh -w  # Watch mode, refresh every 30 seconds; press r to refresh now, q to quit
 ./check-pr.sh -w -i 10  # Watch mode with a 10-second interval
 ./check-pr.sh --concise  # Show only summary and items needing attention
 ./check-pr.sh /path/to/repo  # Check a PR from another repository directory

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 
 # Git workflow helpers behind one dispatcher
 ./gitx.sh status  # Branch, upstream, default-branch, worktree, stashes
+./gitx.sh status --vs main  # Also compare against a deploy branch that is not the default
 ./gitx.sh changed  # Files this branch changed vs the default branch, with +/- counts
 ./gitx.sh changed -i  # Pick a branch with fzf, browse its files with a diff preview
 ./gitx.sh branch feat add git tools  # Create feat/add-git-tools off an updated main

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 ### Development Tools
 
 - **[ai-usage-collect.py](docs/ai-usage-collect.md)** - Collect ccusage-backed AI coding stats from local/SSH hosts in parallel into append-only per-host ledgers, JSON/CSV, an offline-capable responsive dashboard, and a shareable PNG infographic; run via `ai-usage.sh` so uv resolves matplotlib
-- **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, check runner/machine info, reviews, and bot activity (CodeRabbit, etc.)
+- **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, checks sorted worst-first, runner/machine info, previous-run verdict and timing trend (regressed/fixed/slower), reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
+- **[gitx.sh](docs/gitx.md)** - Git workflow dispatcher: branch status, merge-base changed files with +/- counts, conventional branch creation, checkout-free default-branch sync, squash-merge-aware branch cleanup, and wrappers for check-pr and gi-select
 - **[highlight-manager.sh](docs/highlight-manager.md)** - Manage Kindle highlights with DuckDB storage and beautiful terminal display
 
 ### Notifications
@@ -52,8 +53,19 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 # Check status of open PR for current branch
 ./check-pr.sh  # Show one-line merge status plus checks and bot reviews
 ./check-pr.sh -w  # Watch mode, refresh every 30 seconds
+./check-pr.sh -w -i 10  # Watch mode with a 10-second interval
 ./check-pr.sh --concise  # Show only summary and items needing attention
 ./check-pr.sh /path/to/repo  # Check a PR from another repository directory
+
+# Git workflow helpers behind one dispatcher
+./gitx.sh status  # Branch, upstream, default-branch, worktree, stashes
+./gitx.sh changed  # Files this branch changed vs the default branch, with +/- counts
+./gitx.sh changed -i  # Pick a branch with fzf, browse its files with a diff preview
+./gitx.sh branch feat add git tools  # Create feat/add-git-tools off an updated main
+./gitx.sh sync --rebase  # Fetch, fast-forward main, rebase the current branch
+./gitx.sh cleanup  # List merged and squash-merged branches (dry run)
+./gitx.sh cleanup --apply  # Delete them after a gum confirmation
+./gitx.sh pr --concise  # Wraps check-pr.sh
 
 # Collect AI coding-agent usage into JSON/CSV stats, ai-usage.html, and a shareable infographic
 ./ai-usage.sh
@@ -98,6 +110,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 | check-pr           | `uv`, `gh`, `git`                                                                                              |
 | env-diff           | `gum`, `awk`, `sort`                                                                                           |
 | gi-select          | `gum`, gitignore repository                                                                                    |
+| gitx               | `git`; `fzf` and `gum` for pickers and prompts; `uv` + `gh` for `gitx pr`                                      |
 | highlight-manager  | `duckdb`, `gum`, `jq`, `python3`                                                                               |
 | ntfy               | `curl`                                                                                                         |
 | simple-notify      | `curl`                                                                                                         |
@@ -126,6 +139,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
    ```
 
 3. **Set up individual scripts** (see respective documentation for detailed setup):
+
    ```bash
    # Audible authentication
    uvx --from audible-cli audible quickstart
@@ -147,6 +161,7 @@ docs/
 ├── ai-usage-collect.md      # AI coding-agent usage collection
 ├── env-diff.md             # Secret-safe env file diffing
 ├── gi-select.md            # Interactive gitignore generation
+├── gitx.md                 # Git workflow dispatcher
 ├── highlight-manager.md     # Kindle highlights management
 ├── ntfy.md                 # Self-hosted ntfy notifications
 ├── simple-notify.md        # Simplepush notifications

--- a/check-pr.py
+++ b/check-pr.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
+import contextlib
 import io
 import json
 import os
 import re
+import select
 import shutil
 import subprocess
+import sys
+import termios
 import time
+import tty
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -212,6 +217,10 @@ FASTER_RATIO = 0.67
 DURATION_NOISE_SECONDS = 20
 OVERRUN_RATIO = 1.25
 OVERRUN_NOISE_SECONDS = 15
+
+# Cooldown between manual refreshes in watch mode, so holding 'r' cannot turn
+# into a burst of GitHub API calls
+MIN_MANUAL_REFRESH_SECONDS = 3.0
 
 
 def check_trend(row: CheckRow) -> str:
@@ -841,7 +850,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Summarize PR readiness for a git repository.")
     parser.add_argument("directory", nargs="?", help="Repository directory. Defaults to current working directory.")
     parser.add_argument("-C", "--directory", dest="directory_option", help="Repository directory.")
-    parser.add_argument("-w", "--watch", action="store_true", help="Refresh on an interval.")
+    parser.add_argument("-w", "--watch", action="store_true", help="Refresh on an interval; press 'r' to refresh now, 'q' to quit.")
     parser.add_argument("-i", "--interval", type=int, default=30, metavar="SECONDS", help="Watch refresh interval in seconds (default: 30).")
     parser.add_argument("--concise", action="store_true", help="Hide URL/path and passing checks; show only what needs attention.")
     args = parser.parse_args()
@@ -898,12 +907,77 @@ def watch_body(state: PRState | None, message: str | None, *, concise: bool, wid
     return fit_to_height(body, height)
 
 
-def with_watch_footer(body: Text, last_updated: datetime | None, next_refresh: float, warning: str = "") -> Text:
-    remaining = max(0, int(next_refresh - time.monotonic()))
+@contextlib.contextmanager
+def key_reader():
+    """Read single keypresses without waiting for Enter.
+
+    Yields a file descriptor to poll, or None when stdin is not a terminal (a
+    pipe or cron), in which case watch mode simply has no keybindings.
+    """
+    if not sys.stdin.isatty():
+        yield None
+        return
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    try:
+        # cbreak rather than raw: Ctrl-C still raises KeyboardInterrupt
+        tty.setcbreak(fd)
+        yield fd
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+
+def wait_for_key(fd: int | None, timeout: float) -> str:
+    """Wait up to timeout seconds for a keypress, returning it (or "")."""
+    if fd is None:
+        time.sleep(timeout)
+        return ""
+    if not select.select([fd], [], [], timeout)[0]:
+        return ""
+    return os.read(fd, 1).decode(errors="ignore")
+
+
+def drain_input(fd: int | None) -> bool:
+    """Discard keys typed while a refresh was running.
+
+    Keys pressed during a fetch are almost always someone impatiently mashing
+    'r'; replaying them would queue a fetch per keypress. Quit is the exception
+    worth honouring, since a refresh can take several seconds.
+    """
+    if fd is None:
+        return False
+    buffered = ""
+    while select.select([fd], [], [], 0)[0]:
+        chunk = os.read(fd, 1024).decode(errors="ignore")
+        if not chunk:
+            break
+        buffered += chunk
+    return "q" in buffered.lower()
+
+
+def with_watch_footer(
+    body: Text,
+    last_updated: datetime | None,
+    next_refresh: float,
+    warning: str = "",
+    *,
+    refreshing: bool = False,
+    keys: bool = False,
+    note: str = "",
+) -> Text:
     updated = last_updated.strftime("%Y-%m-%d %H:%M:%S") if last_updated else "never"
-    footer = f"\nLast updated at {updated} · next update in {remaining}s"
+    footer = f"\nLast updated at {updated}"
+    if refreshing:
+        footer += " · refreshing now..."
+    else:
+        remaining = max(0, int(next_refresh - time.monotonic()))
+        footer += f" · next update in {remaining}s"
+    if note:
+        footer += f" · {note}"
     if warning:
         footer += f" · last refresh failed: {warning}"
+    if keys:
+        footer += " · [r] refresh  [q] quit"
     output = body.copy()
     output.append(footer, style="grey62")
     return output
@@ -917,12 +991,26 @@ def watch(args: argparse.Namespace) -> int:
     warning = ""
     code = 0
     fetched = False
+    last_fetch_at = 0.0
+    note = ""
+    note_until = 0.0
 
-    with Live(console=console, refresh_per_second=4, transient=False) as live:
+    body: Text | None = None
+
+    with key_reader() as key_fd, Live(console=console, refresh_per_second=4, transient=False) as live:
         try:
             while True:
                 now = time.monotonic()
                 if not fetched or now >= next_refresh:
+                    # Say so before blocking on the network, so a manual refresh
+                    # gives immediate feedback instead of a frozen countdown
+                    if body is not None:
+                        live.update(with_watch_footer(
+                            body, last_updated, next_refresh, warning,
+                            refreshing=True, keys=key_fd is not None,
+                        ))
+                    # Push the next automatic refresh out before fetching, so a
+                    # slow fetch cannot re-enter this branch
                     next_refresh = now + args.interval
                     fetched = True
                     try:
@@ -946,6 +1034,17 @@ def watch(args: argparse.Namespace) -> int:
                         if state is None:
                             message = f"[red]{warning}[/]"
 
+                    # Time the interval from the end of the fetch, so a slow
+                    # fetch does not immediately trigger the next one
+                    last_fetch_at = time.monotonic()
+                    next_refresh = last_fetch_at + args.interval
+                    note = ""
+                    if drain_input(key_fd):
+                        break
+
+                if note and time.monotonic() >= note_until:
+                    note = ""
+
                 # Re-render every tick so a resize is picked up without refetching.
                 # Reserve two lines for the footer plus one for the prompt.
                 width, height = console.size
@@ -956,8 +1055,25 @@ def watch(args: argparse.Namespace) -> int:
                     width=width,
                     height=max(1, height - 3),
                 )
-                live.update(with_watch_footer(body, last_updated, next_refresh, warning))
-                time.sleep(1)
+                live.update(with_watch_footer(
+                    body, last_updated, next_refresh, warning,
+                    keys=key_fd is not None, note=note,
+                ))
+
+                # Sleep in one-second ticks so the countdown stays live, but wake
+                # early on a keypress
+                key = wait_for_key(key_fd, 1.0)
+                if key in {"r", "R"}:
+                    since = time.monotonic() - last_fetch_at
+                    if since < MIN_MANUAL_REFRESH_SECONDS:
+                        # Refusing here is what keeps a held-down 'r' from
+                        # turning into a burst of API calls
+                        note = f"refreshed {since:.0f}s ago, ignoring"
+                        note_until = time.monotonic() + 2
+                    else:
+                        next_refresh = time.monotonic()
+                elif key in {"q", "Q"}:
+                    break
         except KeyboardInterrupt:
             console.print("\n[grey62]Interrupted.[/]")
             return 130

--- a/check-pr.py
+++ b/check-pr.py
@@ -996,8 +996,22 @@ def watch(args: argparse.Namespace) -> int:
     note_until = 0.0
 
     body: Text | None = None
+    body_signature: tuple | None = None
+    painted = ""
+    revision = 0
 
-    with key_reader() as key_fd, Live(console=console, refresh_per_second=4, transient=False) as live:
+    def paint(frame: Text) -> None:
+        """Repaint only when the frame actually differs from what is on screen."""
+        nonlocal painted
+        if frame.plain == painted:
+            return
+        live.update(frame, refresh=True)
+        painted = frame.plain
+
+    # auto_refresh=False: with it on, Rich repaints the whole region several
+    # times a second whether or not anything changed. Every repaint here is
+    # deliberate instead.
+    with key_reader() as key_fd, Live(console=console, auto_refresh=False, transient=False) as live:
         try:
             while True:
                 now = time.monotonic()
@@ -1005,7 +1019,7 @@ def watch(args: argparse.Namespace) -> int:
                     # Say so before blocking on the network, so a manual refresh
                     # gives immediate feedback instead of a frozen countdown
                     if body is not None:
-                        live.update(with_watch_footer(
+                        paint(with_watch_footer(
                             body, last_updated, next_refresh, warning,
                             refreshing=True, keys=key_fd is not None,
                         ))
@@ -1039,23 +1053,30 @@ def watch(args: argparse.Namespace) -> int:
                     last_fetch_at = time.monotonic()
                     next_refresh = last_fetch_at + args.interval
                     note = ""
+                    revision += 1
                     if drain_input(key_fd):
                         break
 
                 if note and time.monotonic() >= note_until:
                     note = ""
 
-                # Re-render every tick so a resize is picked up without refetching.
+                # Rebuild the body only when something it depends on changed. The
+                # countdown ticks every second, but re-rendering every table to
+                # advance a number is wasted work.
                 # Reserve two lines for the footer plus one for the prompt.
                 width, height = console.size
-                body = watch_body(
-                    state,
-                    message,
-                    concise=args.concise,
-                    width=width,
-                    height=max(1, height - 3),
-                )
-                live.update(with_watch_footer(
+                signature = (revision, width, height, args.concise, message)
+                if body is None or signature != body_signature:
+                    body = watch_body(
+                        state,
+                        message,
+                        concise=args.concise,
+                        width=width,
+                        height=max(1, height - 3),
+                    )
+                    body_signature = signature
+
+                paint(with_watch_footer(
                     body, last_updated, next_refresh, warning,
                     keys=key_fd is not None, note=note,
                 ))

--- a/check-pr.py
+++ b/check-pr.py
@@ -11,10 +11,9 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import time
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +24,35 @@ from rich.text import Text
 
 console = Console()
 
+FAILING_STATES = {
+    "FAILURE",
+    "FAILED",
+    "FAILING",
+    "ERROR",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "CANCELED",
+}
+PENDING_STATES = {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"}
+PASSING_STATES = {"SUCCESS", "PASSED", "PASSING"}
+QUIET_STATES = {"SKIPPED", "NEUTRAL"}
+
+# Check links look like .../actions/runs/<run_id>/job/<job_id>, which lets us
+# fetch every job of a run in one API call instead of one call per job.
+RUN_JOB_LINK_RE = re.compile(r"/actions/runs/(\d+)/job/(\d+)")
+JOB_LINK_RE = re.compile(r"/job/(\d+)(?:\D|$)")
+
+
+class CheckPRError(RuntimeError):
+    """A problem worth reporting to the user without a traceback."""
+
+    style = "red"
+
+
+class NoPullRequest(CheckPRError):
+    style = "yellow"
+
 
 @dataclass
 class CheckRow:
@@ -34,6 +62,9 @@ class CheckRow:
     runner: str = ""
     duration: str = ""
     previous_duration: str = ""
+    previous_state: str = ""
+    seconds: float | None = None
+    previous_seconds: float | None = None
 
 
 @dataclass
@@ -41,9 +72,32 @@ class ActionInfo:
     runner: str = ""
     duration: str = ""
     previous_duration: str = ""
+    previous_state: str = ""
     name: str = ""
     workflow: str = ""
     run_id: int | None = None
+    seconds: float | None = None
+    previous_seconds: float | None = None
+
+
+@dataclass
+class PRState:
+    """Everything needed to render, so rendering never re-hits the network."""
+
+    owner: str
+    repo_name: str
+    number: int
+    title: str
+    url: str
+    head: str
+    base: str
+    path: Path
+    draft: bool
+    status_state: str
+    status_detail: str
+    checks: list[CheckRow] = field(default_factory=list)
+    bots: list[tuple[str, str, str]] = field(default_factory=list)
+    attention: list[tuple[str, str, str]] = field(default_factory=list)
 
 
 def run(cmd: list[str], cwd: Path, *, check: bool = True) -> str:
@@ -63,6 +117,8 @@ def friendly_error(exc: Exception) -> str:
         return "GitHub appears to be having problems; try again shortly."
     if "rate limit" in lower:
         return "GitHub API rate limit reached; try again later."
+    if "gh auth login" in lower or "authentication token" in lower or "http 401" in lower:
+        return "Not authenticated with GitHub; run 'gh auth login'."
     return message
 
 
@@ -120,6 +176,104 @@ def check_effective_state(raw: dict[str, Any]) -> str:
     return conclusion or rollup_state or status or "-"
 
 
+def check_sort_key(row: CheckRow) -> tuple[int, str]:
+    """Blockers first, then anything running, then quiet/passing results.
+
+    Within one state the order is alphabetical so a check keeps its position
+    between refreshes instead of shuffling with whatever order gh returned.
+    """
+    state = (row.state or "").upper()
+    if state in FAILING_STATES:
+        rank = 0
+    elif state in PENDING_STATES:
+        rank = 1
+    elif state in PASSING_STATES:
+        rank = 4
+    elif state in QUIET_STATES:
+        rank = 3
+    else:
+        rank = 2
+    return rank, row.name.casefold()
+
+
+TREND_STYLES = {
+    "regressed": "bold red",
+    "still": "red",
+    "fixed": "bold green",
+    "running": "bold yellow",
+    "slower": "yellow",
+    "faster": "green",
+}
+
+# A check has to be both proportionally and absolutely slower before it is worth
+# mentioning, otherwise short jobs flap between "slower" and "faster" on noise.
+SLOWER_RATIO = 1.5
+FASTER_RATIO = 0.67
+DURATION_NOISE_SECONDS = 20
+OVERRUN_RATIO = 1.25
+OVERRUN_NOISE_SECONDS = 15
+
+
+def check_trend(row: CheckRow) -> str:
+    """How this check compares with the previous run of the same job.
+
+    A verdict change outranks a timing change: 'regressed' is the one worth
+    interrupting someone for, since it passed last time and fails now. When the
+    verdict is unchanged, report a materially different runtime instead.
+    """
+    state = (row.state or "").upper()
+    previous = (row.previous_state or "").upper()
+    if not previous:
+        return ""
+
+    now_failing = state in FAILING_STATES
+    now_passing = state in PASSING_STATES
+    was_failing = previous in FAILING_STATES
+    was_passing = previous in PASSING_STATES
+    if now_failing and was_passing:
+        return "regressed"
+    if now_failing and was_failing:
+        return "still failing"
+    if now_passing and was_failing:
+        return "fixed"
+
+    current, before = row.seconds, row.previous_seconds
+    if current is None or before is None or before <= 0:
+        return ""
+    ratio = current / before
+
+    # Still running past its usual time: often a hang rather than slow work
+    if state in PENDING_STATES:
+        if ratio >= OVERRUN_RATIO and current - before >= OVERRUN_NOISE_SECONDS:
+            return f"running long {ratio:.1f}×"
+        return ""
+
+    if not now_passing:
+        return ""
+    if ratio >= SLOWER_RATIO and current - before >= DURATION_NOISE_SECONDS:
+        return f"slower {ratio:.1f}×"
+    if ratio <= FASTER_RATIO and before - current >= DURATION_NOISE_SECONDS:
+        return f"faster {ratio:.1f}×"
+    return ""
+
+
+def name_list(names: list[str], limit: int = 3) -> str:
+    listed = ", ".join(names[:limit])
+    if len(names) > limit:
+        listed += f" and {len(names) - limit} more"
+    return listed
+
+
+def previous_cell(row: CheckRow) -> Text:
+    """Previous run's verdict, with its duration alongside for comparison."""
+    if not row.previous_state:
+        return Text("-", style="grey62")
+    cell = styled(row.previous_state)
+    if row.previous_duration:
+        cell.append(f" {row.previous_duration}", style="grey62")
+    return cell
+
+
 def parse_time(value: str | None) -> datetime | None:
     if not value or value.startswith("0001-"):
         return None
@@ -137,21 +291,21 @@ def format_duration(seconds: float) -> str:
     return f"{secs}s"
 
 
-def job_duration(job: dict[str, Any]) -> str:
+def job_elapsed(job: dict[str, Any]) -> float | None:
+    """Seconds the job has taken, counting to now while it is still running."""
     started = parse_time(job.get("started_at") or job.get("startedAt"))
     if not started:
-        return ""
+        return None
     completed = parse_time(job.get("completed_at") or job.get("completedAt")) or datetime.now(UTC)
-    return format_duration((completed - started).total_seconds())
+    return max(0.0, (completed - started).total_seconds())
 
 
-def action_info(link: str, owner: str, repo_name: str, cwd: Path) -> ActionInfo:
-    match = re.search(r"/job/(\d+)(?:\D|$)", link or "")
-    if not match:
-        return ActionInfo()
-    job = run_json(["gh", "api", f"repos/{owner}/{repo_name}/actions/jobs/{match.group(1)}"], cwd, check=False)
-    if not isinstance(job, dict):
-        return ActionInfo()
+def job_duration(job: dict[str, Any]) -> str:
+    seconds = job_elapsed(job)
+    return "" if seconds is None else format_duration(seconds)
+
+
+def job_to_info(job: dict[str, Any]) -> ActionInfo:
     runner = str(job.get("runner_name") or "")
     labels = job.get("labels") or []
     if not runner and isinstance(labels, list) and labels:
@@ -160,42 +314,97 @@ def action_info(link: str, owner: str, repo_name: str, cwd: Path) -> ActionInfo:
     return ActionInfo(
         runner=runner,
         duration=job_duration(job),
+        seconds=job_elapsed(job),
         name=str(job.get("name") or ""),
         workflow=str(job.get("workflow_name") or ""),
         run_id=int(run_id) if isinstance(run_id, int) else None,
     )
 
 
-def previous_durations(infos: dict[str, ActionInfo], owner: str, repo_name: str, branch: str, cwd: Path) -> dict[tuple[str, str], str]:
-    wanted = {(info.workflow, info.name) for info in infos.values() if info.workflow and info.name}
-    current_runs = {info.run_id for info in infos.values() if info.run_id}
-    if not wanted:
-        return {}
-    runs = run_json([
+def run_jobs(owner: str, repo_name: str, run_id: int, cwd: Path) -> list[dict[str, Any]]:
+    data = run_json(
+        [
+            "gh", "api", "--method", "GET",
+            f"repos/{owner}/{repo_name}/actions/runs/{run_id}/jobs",
+            "-f", "per_page=100",
+        ],
+        cwd,
+        check=False,
+    )
+    return data.get("jobs", []) if isinstance(data, dict) else []
+
+
+def action_info(link: str, owner: str, repo_name: str, cwd: Path) -> ActionInfo:
+    """Single-job lookup, used only for links without a run id."""
+    match = JOB_LINK_RE.search(link or "")
+    if not match:
+        return ActionInfo()
+    job = run_json(["gh", "api", f"repos/{owner}/{repo_name}/actions/jobs/{match.group(1)}"], cwd, check=False)
+    if not isinstance(job, dict):
+        return ActionInfo()
+    return job_to_info(job)
+
+
+def branch_runs(owner: str, repo_name: str, branch: str, cwd: Path) -> Any:
+    """Recent PR workflow runs for a branch. Independent of the job listings, so
+    callers fetch it concurrently with them."""
+    return run_json([
         "gh", "api", "--method", "GET", f"repos/{owner}/{repo_name}/actions/runs",
         "-f", f"branch={branch}", "-f", "event=pull_request", "-f", "per_page=30",
     ], cwd, check=False)
-    candidates = [
-        run for run in (runs or {}).get("workflow_runs", [])
-        if run.get("id") not in current_runs and (run.get("name"), "") not in wanted
-    ]
-    candidates = [run for run in candidates if run.get("name") in {workflow for workflow, _ in wanted}]
-    found: dict[tuple[str, str], str] = {}
 
-    def run_jobs(run_id: int) -> list[dict[str, Any]]:
-        data = run_json(["gh", "api", "--method", "GET", f"repos/{owner}/{repo_name}/actions/runs/{run_id}/jobs", "-f", "per_page=100"], cwd, check=False)
-        return data.get("jobs", []) if isinstance(data, dict) else []
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(6, len(candidates) or 1)) as executor:
-        future_to_run = {executor.submit(run_jobs, int(run["id"])): run for run in candidates[:12] if run.get("id")}
-        for future in concurrent.futures.as_completed(future_to_run):
-            workflow = str(future_to_run[future].get("name") or "")
-            for job in future.result():
+def previous_results(infos: dict[str, ActionInfo], runs: Any, owner: str, repo_name: str, cwd: Path) -> dict[tuple[str, str], tuple[str, str, float | None]]:
+    """How each job ended, and how long it took, in the previous run.
+
+    Returns {(workflow, job): (conclusion, duration, seconds)}. Runs that were cancelled
+    (typically superseded by a newer push) are skipped: their jobs stop at an
+    arbitrary point, so they say nothing about whether a check used to pass.
+    """
+    wanted = {(info.workflow, info.name) for info in infos.values() if info.workflow and info.name}
+    if not wanted:
+        return {}
+    current_runs = {info.run_id for info in infos.values() if info.run_id}
+    workflows = {workflow for workflow, _ in wanted}
+
+    # The API returns newest first, so the first match per workflow wins. One
+    # job listing per workflow beats one per candidate run.
+    newest: dict[str, int] = {}
+    for workflow_run in (runs or {}).get("workflow_runs", []):
+        name = str(workflow_run.get("name") or "")
+        run_id = workflow_run.get("id")
+        if name not in workflows or name in newest:
+            continue
+        if run_id in current_runs or not isinstance(run_id, int):
+            continue
+        if str(workflow_run.get("status") or "") != "completed":
+            continue
+        if str(workflow_run.get("conclusion") or "") not in {"success", "failure"}:
+            continue
+        newest[name] = run_id
+
+    if not newest:
+        return {}
+
+    found: dict[tuple[str, str], tuple[str, str, float | None]] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(6, len(newest))) as executor:
+        results = executor.map(
+            lambda item: (item[0], run_jobs(owner, repo_name, item[1], cwd)),
+            newest.items(),
+        )
+        for workflow, jobs in results:
+            for job in jobs:
                 key = (workflow, str(job.get("name") or ""))
-                if key in wanted and key not in found:
-                    duration = job_duration(job)
-                    if duration:
-                        found[key] = duration
+                if key not in wanted or key in found:
+                    continue
+                conclusion = str(job.get("conclusion") or "").upper()
+                if not job.get("completed_at") or not conclusion:
+                    continue
+                # Only a job that ran to a verdict has a comparable duration
+                comparable = conclusion in {"SUCCESS", "FAILURE", "TIMED_OUT"}
+                duration = job_duration(job) if comparable else ""
+                seconds = job_elapsed(job) if comparable else None
+                found[key] = (conclusion, duration, seconds)
     return found
 
 
@@ -203,16 +412,56 @@ def action_infos(links: list[str], owner: str, repo_name: str, branch: str, cwd:
     unique_links = sorted({link for link in links if link})
     if not unique_links:
         return {}
-    max_workers = min(8, len(unique_links))
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        infos = dict(zip(
-            unique_links,
-            executor.map(lambda link: action_info(link, owner, repo_name, cwd), unique_links),
-            strict=True,
-        ))
-    previous = previous_durations(infos, owner, repo_name, branch, cwd)
+
+    # Group by workflow run so each run costs one API call, no matter how many
+    # of its jobs appear as checks on the PR.
+    by_run: dict[int, list[str]] = {}
+    loose_links: list[str] = []
+    for link in unique_links:
+        match = RUN_JOB_LINK_RE.search(link)
+        if match:
+            by_run.setdefault(int(match.group(1)), []).append(link)
+        else:
+            loose_links.append(link)
+
+    infos: dict[str, ActionInfo] = {}
+    runs: Any = None
+
+    if by_run:
+        # The branch's run history does not depend on the job listings, so it
+        # rides along instead of costing an extra round trip afterwards
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(by_run) + 1)) as executor:
+            runs_future = executor.submit(branch_runs, owner, repo_name, branch, cwd)
+            fetched = list(executor.map(
+                lambda run_id: (run_id, run_jobs(owner, repo_name, run_id, cwd)),
+                list(by_run),
+            ))
+            runs = runs_future.result()
+
+        for run_id, jobs in fetched:
+            index = {int(job["id"]): job for job in jobs if isinstance(job.get("id"), int)}
+            for link in by_run[run_id]:
+                match = RUN_JOB_LINK_RE.search(link)
+                job = index.get(int(match.group(2))) if match else None
+                if job:
+                    infos[link] = job_to_info(job)
+
+    if loose_links:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(loose_links))) as executor:
+            for link, info in zip(
+                loose_links,
+                executor.map(lambda link: action_info(link, owner, repo_name, cwd), loose_links),
+                strict=True,
+            ):
+                infos[link] = info
+
+    if runs is None:
+        runs = branch_runs(owner, repo_name, branch, cwd)
+    previous = previous_results(infos, runs, owner, repo_name, cwd)
     for info in infos.values():
-        info.previous_duration = previous.get((info.workflow, info.name), "")
+        info.previous_state, info.previous_duration, info.previous_seconds = previous.get(
+            (info.workflow, info.name), ("", "", None)
+        )
     return infos
 
 
@@ -228,10 +477,20 @@ def build_checks(pr: dict[str, Any], number: int, owner: str, repo_name: str, br
                 "FAILURE": "failed",
                 "SKIPPED": "skipped",
                 "CANCELLED": "cancelled",
-            }.get(state, "running" if state in {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"} else "")
+            }.get(state, "running" if state in PENDING_STATES else "")
             link = item.get("link") or ""
             info = infos.get(link, ActionInfo())
-            rows.append(CheckRow(item.get("name") or "unknown", state, detail or state.lower(), info.runner, info.duration, info.previous_duration))
+            rows.append(CheckRow(
+                name=item.get("name") or "unknown",
+                state=state,
+                details=detail or state.lower(),
+                runner=info.runner,
+                duration=info.duration,
+                previous_duration=info.previous_duration,
+                previous_state=info.previous_state,
+                seconds=info.seconds,
+                previous_seconds=info.previous_seconds,
+            ))
         return rows
 
     rollup = pr.get("statusCheckRollup") or []
@@ -242,7 +501,17 @@ def build_checks(pr: dict[str, Any], number: int, owner: str, repo_name: str, br
         detail = "completed" if item.get("conclusion") else "running"
         link = item.get("detailsUrl") or ""
         info = infos.get(link, ActionInfo())
-        rows.append(CheckRow(name, state, detail, info.runner, info.duration, info.previous_duration))
+        rows.append(CheckRow(
+            name=name,
+            state=state,
+            details=detail,
+            runner=info.runner,
+            duration=info.duration,
+            previous_duration=info.previous_duration,
+            previous_state=info.previous_state,
+            seconds=info.seconds,
+            previous_seconds=info.previous_seconds,
+        ))
     if not rows:
         rows.append(CheckRow("(no checks reported)", "-", ""))
     return rows
@@ -251,9 +520,8 @@ def build_checks(pr: dict[str, Any], number: int, owner: str, repo_name: str, br
 def check_summary(checks: list[CheckRow]) -> tuple[str, str]:
     if not checks or checks[0].name == "(no checks reported)":
         return "NONE", "no checks reported"
-    failing = sum(1 for c in checks if c.state in {"FAILURE", "FAILED", "FAILING", "ERROR", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "CANCELED"})
-    pending = sum(1 for c in checks if c.state in {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"})
-    passing = sum(1 for c in checks if c.state in {"SUCCESS", "PASSED", "PASSING"})
+    failing = sum(1 for c in checks if c.state in FAILING_STATES)
+    pending = sum(1 for c in checks if c.state in PENDING_STATES)
     if failing:
         state = "FAILING"
     elif pending:
@@ -319,7 +587,7 @@ def bot_activity(comments: list[dict[str, Any]], checks: list[CheckRow]) -> tupl
         joined = "\n".join(bodies).lower()
         key = bot.lower().removesuffix("ai")
         bot_check_state = next((state for name, state in check_names.items() if name.startswith(key)), "")
-        bot_check_running = bot_check_state in {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"}
+        bot_check_running = bot_check_state in PENDING_STATES
         latest_is_skip = "review skipped" in latest or "skip review" in latest
         latest_is_review = any(marker in latest for marker in ("review_stack_entry_start", "walkthrough", "out of diff", "review details", "summary by coderabbit"))
         skipped = latest_is_skip and not latest_is_review and not bot_check_running
@@ -347,43 +615,67 @@ def bot_activity(comments: list[dict[str, Any]], checks: list[CheckRow]) -> tupl
         else:
             state = "COMMENTED"
             details = f"{len(bodies)} issue comment(s)"
-            if any(name.startswith(key) and state == "SUCCESS" for name, state in check_names.items()):
+            if any(name.startswith(key) and check_state in PASSING_STATES for name, check_state in check_names.items()):
                 details += ", check success"
         rows.append((bot, state, details))
     return rows, coderabbit_skipped
 
 
-def render(args: argparse.Namespace, out: Console = console, footer: str | None = None) -> int:
+def effective_review_state(reviews: list[dict[str, Any]], review_decision: str) -> str:
+    """Latest decisive review per user; COMMENTED never overrides an approval."""
+    latest_by_user: dict[str, str] = {}
+    for review in reviews:
+        state = str(review.get("state") or "").upper()
+        if state not in {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}:
+            continue
+        user = ((review.get("user") or {}).get("login")) or "unknown"
+        if state == "DISMISSED":
+            latest_by_user.pop(user, None)
+            continue
+        latest_by_user[user] = state
+
+    states = set(latest_by_user.values())
+    if "CHANGES_REQUESTED" in states:
+        return "CHANGES_REQUESTED"
+    if "APPROVED" in states:
+        return "APPROVED"
+    return review_decision
+
+
+def collect_state(args: argparse.Namespace) -> PRState:
+    """Gather everything from git/gh. Raises CheckPRError for user problems."""
     cwd = Path(args.directory or os.getcwd()).expanduser().resolve()
     if not cwd.exists():
-        out.print(f"[red]Directory does not exist:[/] {cwd}")
-        return 1
+        raise CheckPRError(f"Directory does not exist: {cwd}")
     for cmd in ("git", "gh"):
         if not shutil.which(cmd):
-            out.print(f"[red]{cmd} is required[/]")
-            return 1
+            raise CheckPRError(f"{cmd} is required")
 
     if run(["git", "rev-parse", "--is-inside-work-tree"], cwd, check=False).strip() != "true":
-        out.print(f"[red]Directory is not inside a git repository:[/] {cwd}")
-        return 1
+        raise CheckPRError(f"Directory is not inside a git repository: {cwd}")
 
     branch = run(["git", "branch", "--show-current"], cwd).strip()
     if not branch:
-        out.print("[red]Could not determine current git branch[/]")
-        return 1
+        raise CheckPRError("Could not determine current git branch")
 
-    repo = run_json(["gh", "repo", "view", "--json", "owner,name"], cwd)
+    # The repo lookup and the PR lookup are independent, so overlap them
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        repo_future = executor.submit(run_json, ["gh", "repo", "view", "--json", "owner,name"], cwd)
+        pr_future = executor.submit(run_json, [
+            "gh", "pr", "list", "--head", branch, "--state", "open",
+            "--json", "number,title,url,headRefName,baseRefName,isDraft,reviewDecision,mergeStateStatus,mergeable,statusCheckRollup",
+            "--limit", "1",
+        ], cwd)
+        repo = repo_future.result()
+        pr_list = pr_future.result()
+
+    if not isinstance(repo, dict) or not repo.get("owner"):
+        raise CheckPRError("Could not determine the GitHub repository for this directory")
     owner = repo["owner"]["login"]
     repo_name = repo["name"]
 
-    pr_list = run_json([
-        "gh", "pr", "list", "--head", branch, "--state", "open",
-        "--json", "number,title,url,headRefName,baseRefName,isDraft,reviewDecision,mergeStateStatus,mergeable,statusCheckRollup",
-        "--limit", "1",
-    ], cwd)
     if not pr_list:
-        out.print(f"[yellow]No open PR found for {owner}/{repo_name} branch: {branch}[/]")
-        return 1
+        raise NoPullRequest(f"No open PR found for {owner}/{repo_name} branch: {branch}")
 
     pr = pr_list[0]
     number = int(pr["number"])
@@ -394,12 +686,15 @@ def render(args: argparse.Namespace, out: Console = console, footer: str | None 
         comments = comments_future.result() or []
         reviews = reviews_future.result() or []
         checks = checks_future.result()
+
     bots, coderabbit_skipped = bot_activity(comments, checks)
     if coderabbit_skipped:
         for check in checks:
             if check.name.lower() == "coderabbit":
                 check.state = "SKIPPED"
                 check.details = "review skipped"
+
+    checks.sort(key=check_sort_key)
 
     check_state, check_details = check_summary(checks)
     draft = bool(pr.get("isDraft"))
@@ -419,18 +714,8 @@ def render(args: argparse.Namespace, out: Console = console, footer: str | None 
     else:
         base_state = merge
 
-    latest_by_user: dict[str, str] = {}
-    for review in reviews:
-        user = ((review.get("user") or {}).get("login")) or "unknown"
-        latest_by_user[user] = review.get("state") or ""
-    states = set(latest_by_user.values())
-    review_decision = pr.get("reviewDecision") or "REVIEW_REQUIRED"
-    if "CHANGES_REQUESTED" in states:
-        effective_review = "CHANGES_REQUESTED"
-    elif "APPROVED" in states:
-        effective_review = "APPROVED"
-    else:
-        effective_review = review_decision
+    effective_review = effective_review_state(reviews, pr.get("reviewDecision") or "REVIEW_REQUIRED")
+
     attention: list[tuple[str, str, str]] = []
     if draft:
         attention.append(("Draft", "DRAFT", "Mark ready for review; draft PRs can suppress actions/checks."))
@@ -442,10 +727,17 @@ def render(args: argparse.Namespace, out: Console = console, footer: str | None 
         attention.append(("Review", effective_review, "Resolve requested changes."))
     elif effective_review == "REVIEW_REQUIRED":
         attention.append(("Review", effective_review, "Get an approving review."))
-    if check_state == "FAILING":
+    if check_state in {"FAILING", "PENDING"}:
         attention.append(("Checks", check_state, check_details + "."))
-    elif check_state == "PENDING":
-        attention.append(("Checks", check_state, check_details + "."))
+
+    # A check that passed last run and fails now points at the latest push
+    regressed = [c.name for c in checks if check_trend(c) == "regressed"]
+    if regressed:
+        attention.append(("Regressions", "FAILURE", f"{name_list(regressed)}: passed in the previous run."))
+
+    overrunning = [c.name for c in checks if check_trend(c).startswith("running long")]
+    if overrunning:
+        attention.append(("Slow checks", "PENDING", f"{name_list(overrunning)}: running longer than the previous run."))
 
     status_state, status_detail = merge_status_line(
         draft=draft,
@@ -456,55 +748,92 @@ def render(args: argparse.Namespace, out: Console = console, footer: str | None 
         effective_review=effective_review,
     )
 
-    out.rule(f"[bold magenta]{owner}/{repo_name} PR #{number} · {pr.get('title')}[/]", characters="─")
-    out.print(f"branch  {shorten(head, 42)} → {base}")
-    if not args.concise:
-        out.print(f"path    {cwd}")
-        out.print(f"url     {pr.get('url')}")
-    out.print("status  ", styled(status_state), f" {status_detail}", sep="")
+    return PRState(
+        owner=owner,
+        repo_name=repo_name,
+        number=number,
+        title=str(pr.get("title") or ""),
+        url=str(pr.get("url") or ""),
+        head=head,
+        base=base,
+        path=cwd,
+        draft=draft,
+        status_state=status_state,
+        status_detail=status_detail,
+        checks=checks,
+        bots=bots,
+        attention=attention,
+    )
 
-    if attention:
+
+def render_state(state: PRState, out: Console, *, concise: bool, footer: str | None = None) -> None:
+    out.rule(f"[bold magenta]{state.owner}/{state.repo_name} PR #{state.number} · {state.title}[/]", characters="─")
+    out.print(f"branch  {shorten(state.head, 42)} → {state.base}")
+    if not concise:
+        out.print(f"path    {state.path}")
+        out.print(f"url     {state.url}")
+    out.print("status  ", styled(state.status_state), f" {state.status_detail}", sep="")
+
+    if state.attention:
         needs = table("Needs attention", ["Item", "State", "Why it matters"])
-        for item, state, why in attention:
-            needs.add_row(item, styled(state), why)
+        for item, item_state, why in state.attention:
+            needs.add_row(item, styled(item_state), why)
         out.print(needs)
 
-    visible_checks = [c for c in checks if not args.concise or c.state not in {"SUCCESS", "PASSED", "PASSING"}]
+    visible_checks = [c for c in state.checks if not concise or c.state not in PASSING_STATES]
     if visible_checks:
         check_columns = ["Check", "State"]
         show_runners = any(c.runner for c in visible_checks)
-        show_durations = any(c.duration or c.previous_duration for c in visible_checks)
+        show_durations = any(c.duration for c in visible_checks)
+        show_previous = any(c.previous_state for c in visible_checks)
+        show_trend = any(check_trend(c) for c in visible_checks)
+        if show_trend:
+            check_columns.append("Trend")
         if show_runners:
             check_columns.append("Runner")
         if show_durations:
             check_columns.append("Time")
+        if show_previous:
+            check_columns.append("Previous")
         checks_table = table("Checks", check_columns)
         for c in visible_checks:
-            row = [c.name, styled(c.state)]
+            row: list[str | Text] = [c.name, styled(c.state)]
+            if show_trend:
+                trend = check_trend(c)
+                # Trends carry a ratio suffix ("slower 2.1×"), so key on the verb
+                row.append(Text(trend, style=TREND_STYLES.get(trend.split(" ")[0], "grey62")))
             if show_runners:
                 row.append(c.runner or "-")
             if show_durations:
-                duration = c.duration or "-"
-                if c.previous_duration:
-                    duration += f" (prev {c.previous_duration})"
-                row.append(duration)
+                row.append(c.duration or "-")
+            if show_previous:
+                row.append(previous_cell(c))
             checks_table.add_row(*row)
         out.print(checks_table)
 
     visible_bots = [
         b
-        for b in bots
-        if not args.concise
-        or b[1] in {"SKIPPED", "WARNING", "BLOCKED", "RATE_LIMITED", "PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"}
+        for b in state.bots
+        if not concise
+        or b[1] in {"SKIPPED", "WARNING", "BLOCKED", "RATE_LIMITED", *PENDING_STATES}
         or "review comments posted" in b[2]
     ]
     if visible_bots:
         bot_table = table("Bot activity", ["Bot", "State", "Details"])
-        for bot, state, details in visible_bots:
-            bot_table.add_row(bot, styled(state), details)
+        for bot, bot_state, details in visible_bots:
+            bot_table.add_row(bot, styled(bot_state), details)
         out.print(bot_table)
     if footer:
         out.print(f"\n[grey62]{footer}[/]")
+
+
+def render(args: argparse.Namespace, out: Console = console, footer: str | None = None) -> int:
+    try:
+        state = collect_state(args)
+    except CheckPRError as exc:
+        out.print(f"[{exc.style}]{exc}[/]")
+        return 1
+    render_state(state, out, concise=args.concise, footer=footer)
     return 0
 
 
@@ -512,30 +841,61 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Summarize PR readiness for a git repository.")
     parser.add_argument("directory", nargs="?", help="Repository directory. Defaults to current working directory.")
     parser.add_argument("-C", "--directory", dest="directory_option", help="Repository directory.")
-    parser.add_argument("-w", "--watch", action="store_true", help="Refresh every 30 seconds.")
+    parser.add_argument("-w", "--watch", action="store_true", help="Refresh on an interval.")
+    parser.add_argument("-i", "--interval", type=int, default=30, metavar="SECONDS", help="Watch refresh interval in seconds (default: 30).")
     parser.add_argument("--concise", action="store_true", help="Hide URL/path and passing checks; show only what needs attention.")
     args = parser.parse_args()
     if args.directory and args.directory_option:
         parser.error("specify only one directory")
+    if args.interval < 5:
+        parser.error("--interval must be at least 5 seconds")
     args.directory = args.directory_option or args.directory
     return args
 
 
-def render_text(args: argparse.Namespace, footer: str | None = None) -> tuple[Text, int]:
+def capture(width: int, render_fn) -> Text:
+    """Render into a Text so watch mode can measure and trim the output."""
     buffer = io.StringIO()
     capture_console = Console(
         file=buffer,
         force_terminal=True,
         color_system=console.color_system,
-        width=console.width,
+        width=width,
         legacy_windows=False,
     )
-    try:
-        code = render(args, capture_console, footer)
-    except Exception as exc:  # noqa: BLE001 - CLI should render errors cleanly
-        capture_console.print(f"[red]{friendly_error(exc)}[/]")
-        code = 1
-    return Text.from_ansi(buffer.getvalue()), code
+    render_fn(capture_console)
+    return Text.from_ansi(buffer.getvalue().rstrip("\n"))
+
+
+def fit_to_height(body: Text, max_lines: int) -> Text:
+    """Trim from the bottom, leaving a marker, so the footer stays visible."""
+    if max_lines <= 1:
+        return body
+    lines = body.split("\n")
+    if len(lines) <= max_lines:
+        return body
+    hidden = len(lines) - (max_lines - 1)
+    trimmed = Text("\n").join(lines[: max_lines - 1])
+    trimmed.append(f"\n… {hidden} more line(s) hidden; use --concise or a taller terminal", style="grey62")
+    return trimmed
+
+
+def watch_body(state: PRState | None, message: str | None, *, concise: bool, width: int, height: int) -> Text:
+    """Render state to fit the terminal, dropping detail before truncating."""
+    if state is None:
+        return Text.from_ansi(message or "Waiting for data...")
+
+    body = capture(width, lambda out: render_state(state, out, concise=concise))
+    if len(body.split("\n")) <= height and not message:
+        return body
+
+    # Too tall: try the compact view before resorting to hard truncation
+    if not concise:
+        compact = capture(width, lambda out: render_state(state, out, concise=True))
+        if len(compact.split("\n")) <= height:
+            return compact
+        body = compact
+    return fit_to_height(body, height)
 
 
 def with_watch_footer(body: Text, last_updated: datetime | None, next_refresh: float, warning: str = "") -> Text:
@@ -550,30 +910,52 @@ def with_watch_footer(body: Text, last_updated: datetime | None, next_refresh: f
 
 
 def watch(args: argparse.Namespace) -> int:
-    interval = 30
     last_updated: datetime | None = None
     next_refresh = time.monotonic()
-    body: Text | None = None
+    state: PRState | None = None
+    message: str | None = None
     warning = ""
     code = 0
+    fetched = False
 
     with Live(console=console, refresh_per_second=4, transient=False) as live:
         try:
             while True:
                 now = time.monotonic()
-                if body is None or now >= next_refresh:
-                    next_refresh = now + interval
-                    new_body, new_code = render_text(args)
-                    if new_code == 0 or body is None:
-                        body = new_body
-                        code = new_code
-                        warning = "" if new_code == 0 else new_body.plain.strip().splitlines()[-1]
-                        if new_code == 0:
-                            last_updated = datetime.now()
-                    else:
-                        warning = new_body.plain.strip().splitlines()[-1]
-                        code = new_code
+                if not fetched or now >= next_refresh:
+                    next_refresh = now + args.interval
+                    fetched = True
+                    try:
+                        state = collect_state(args)
+                        message = None
+                        warning = ""
+                        code = 0
+                        last_updated = datetime.now()
+                    except CheckPRError as exc:
+                        # Expected condition (no PR yet, wrong directory): show
+                        # it as the body rather than as a refresh failure
+                        code = 1
+                        if state is None:
+                            message = f"[{exc.style}]{exc}[/]"
+                            warning = ""
+                        else:
+                            warning = friendly_error(exc)
+                    except Exception as exc:  # noqa: BLE001 - keep watching
+                        code = 1
+                        warning = friendly_error(exc)
+                        if state is None:
+                            message = f"[red]{warning}[/]"
 
+                # Re-render every tick so a resize is picked up without refetching.
+                # Reserve two lines for the footer plus one for the prompt.
+                width, height = console.size
+                body = watch_body(
+                    state,
+                    message,
+                    concise=args.concise,
+                    width=width,
+                    height=max(1, height - 3),
+                )
                 live.update(with_watch_footer(body, last_updated, next_refresh, warning))
                 time.sleep(1)
         except KeyboardInterrupt:

--- a/docs/gitx.md
+++ b/docs/gitx.md
@@ -197,6 +197,10 @@ gitx pr -w                 # watch mode
 gitx pr -w -i 10           # watch, refreshing every 10 seconds
 ```
 
+In watch mode, `r` refreshes immediately and `q` quits. Manual refreshes have a
+three-second cooldown, and keys pressed while a refresh is in flight are discarded, so
+holding `r` down cannot turn into a burst of API calls.
+
 ### gitignore
 
 Append GitHub's gitignore templates to `./.gitignore`, chosen with gum. Delegates to

--- a/docs/gitx.md
+++ b/docs/gitx.md
@@ -48,7 +48,8 @@ colors, and interactive pickers.
 | `git`         | everything                                          |
 | `fzf`         | branch and changed-file pickers (`changed -i`)      |
 | `gum`         | prompts, spinners, `cleanup` selection, `gitignore` |
-| `uv` and `gh` | `gitx pr` (delegates to `check-pr.sh`)              |
+| `uv` and `gh` | `gitx pr check` (delegates to `check-pr.sh`)        |
+| `gh` and `jq` | `gitx pr list`                                      |
 
 `fzf` and `gum` are optional: without them the pickers degrade to non-interactive output
 and prompts fall back to a plain `read`.
@@ -63,7 +64,7 @@ gitx/lib/changed.sh     # gitx changed
 gitx/lib/branch.sh      # gitx branch
 gitx/lib/sync.sh        # gitx sync
 gitx/lib/cleanup.sh     # gitx cleanup
-gitx/lib/pr.sh          # gitx pr      -> check-pr.sh
+gitx/lib/pr.sh          # gitx pr check -> check-pr.sh, and gitx pr list
 gitx/lib/gitignore.sh   # gitx gitignore -> gi-select.sh
 ```
 
@@ -207,21 +208,52 @@ only squash-merged ones need `-D`, since git cannot see the equivalence itself.
 the merge base, then `git cherry` is asked whether an equivalent patch already exists on
 the default branch. The probe commit is never referenced, so it is garbage collected.
 
-### pr
+### pr check
 
-PR merge status, checks, reviews, and bot activity. Delegates to `check-pr.sh`, so every
-option it accepts works here.
+PR merge status, checks, reviews, and bot activity for the current branch. Delegates to
+`check-pr.sh`, so every option it accepts works here. A bare `gitx pr` runs `check`.
 
 ```bash
-gitx pr
-gitx pr --concise
-gitx pr -w                 # watch mode
-gitx pr -w -i 10           # watch, refreshing every 10 seconds
+gitx pr check
+gitx pr check --concise
+gitx pr check -w                 # watch mode
+gitx pr check -w -i 10           # watch, refreshing every 10 seconds
 ```
 
 In watch mode, `r` refreshes immediately and `q` quits. Manual refreshes have a
 three-second cooldown, and keys pressed while a refresh is in flight are discarded, so
 holding `r` down cannot turn into a burst of API calls.
+
+### pr list
+
+Open PRs with the two things `gh pr list` leaves out of easy reach: **who opened each one**
+and **which branch it targets**. A destination that is not the default branch is
+highlighted, and counted in the footer — that is usually the interesting case, either a
+release promotion or a PR aimed at the wrong branch.
+
+```bash
+gitx pr list
+gitx pr list --mine
+gitx pr list --base main            # what is queued for the deploy branch
+gitx pr list -H                     # also show the source branch
+gitx pr list --state merged -L 10
+gitx pr list -i | xargs -n1 gh pr view
+```
+
+```
+  1007  stonecharioteer  main         draft  chore: promote development to …  3m
+   999  Bukkaraya        development  draft  Add admin-only chat model pick…  4d
+   960  stonecharioteer  development         fix: fail fast on non-dev data…  1w
+
+  12 pull requests, 1 not targeting development
+```
+
+The flag column shows `draft`, `approved`, or `changes` (changes requested), so a listing
+doubles as a review queue. Titles are truncated to the terminal width; everything else is
+sized to its content. `-i` picks PRs with fzf, previewing `gh pr view`, and prints the
+selected numbers to stdout so they pipe into `gh`.
+
+This is one `gh pr list` call plus `jq`, so it is a single round trip.
 
 ### gitignore
 
@@ -263,7 +295,11 @@ gitx gi
 | `branch`    | `new`    |
 | `sync`      | `update` |
 | `cleanup`   | `tidy`   |
+| `pr list`   | `pr ls`  |
 | `gitignore` | `gi`     |
+
+A bare `gitx pr` runs `pr check`, and `gitx pr --concise` still works, so the older
+single-level form keeps functioning.
 
 ## Suggested Alias
 

--- a/docs/gitx.md
+++ b/docs/gitx.md
@@ -28,8 +28,11 @@ colors, and interactive pickers.
   branch after you branched off
 - **Squash-merge detection** - `cleanup` finds branches GitHub squashed, which
   `git branch --merged` misses entirely
-- **Default branch detection** - reads the remote's `HEAD` symref, with fallbacks, so it
-  works on `main`, `master`, `development`, or `trunk` without configuration
+- **Default branch detection** - reads the remote's `HEAD` symref, and asks the remote
+  directly when a local guess would be ambiguous, so a repo whose default is `development`
+  but which also has a `main` is not mistaken for a `main` repo
+- **Deploy-branch awareness** - `status --vs main` reports where you sit relative to any
+  other branch, for repos where the default branch is not the one you ship from
 - **Checkout-free updates** - `sync` fast-forwards the default branch while you stay on
   your feature branch
 - **fzf and gum throughout** - branch and file pickers with live diff previews, gum
@@ -85,6 +88,25 @@ Worktree    0 staged, 1 unstaged, 9 untracked
 Stashes     none
 Last commit 2b3b0d6 Merge pull request #29 (5 days ago)
 ```
+
+**Comparing against another branch.** When the branch you deploy from is not the default
+branch, `--vs` adds a `Compare` row. Repeat it for more than one, or set
+`GITX_STATUS_COMPARE` once per repo:
+
+```bash
+gitx status --vs main                    # development is default, main deploys
+gitx status --vs main --vs staging
+GITX_STATUS_COMPARE=main gitx status
+```
+
+```
+Default     development (tracking origin/development)
+Position    ahead 2, behind 0 vs origin/development
+Compare     ahead 20, behind 21 vs origin/main
+```
+
+A ref that does not exist is reported in place rather than being fatal, so a stale entry in
+`GITX_STATUS_COMPARE` cannot break the command.
 
 ### changed
 
@@ -229,6 +251,7 @@ gitx gi
 | `GITX_REMOTE`             | Default remote name                        |
 | `GITX_DEFAULT_BRANCH`     | Default branch name, skipping detection    |
 | `GITX_PROTECTED_BRANCHES` | Extra branches `cleanup` must never delete |
+| `GITX_STATUS_COMPARE`     | Default `--vs` refs for `status`           |
 | `NO_COLOR`                | Disable colored output                     |
 
 ## Command Aliases

--- a/docs/gitx.md
+++ b/docs/gitx.md
@@ -1,0 +1,257 @@
+# gitx - Git Workflow Helpers
+
+`gitx.sh` is a single entry point for the everyday feature-branch loop: start a branch,
+see what it changed, check the PR, keep up with the default branch, and clean up
+afterwards.
+
+## Why This Exists
+
+The individual pieces were already here — `check-pr.sh` for PR status, `gi-select.sh` for
+gitignore templates — but everything else lived in shell history as half-remembered
+plumbing. Three problems kept recurring:
+
+- **"What did this branch actually change?"** `git diff main` answers the wrong question
+  once `main` has moved on. The right answer needs the merge base, which nobody types by
+  hand every time.
+- **Squash-merged branches pile up.** `git branch --merged` never lists them, because a
+  squash merge shares no commits with the branch it came from. They accumulate until you
+  delete them by memory and hope.
+- **Every repo has a different default branch.** `main`, `master`, `development`, `trunk`.
+  Hardcoding one guarantees the helper breaks on the next repo.
+
+`gitx` solves each once, then puts them behind one dispatcher with consistent help,
+colors, and interactive pickers.
+
+## Features
+
+- **Merge-base aware diffs** - `changed` never reports commits that landed on the default
+  branch after you branched off
+- **Squash-merge detection** - `cleanup` finds branches GitHub squashed, which
+  `git branch --merged` misses entirely
+- **Default branch detection** - reads the remote's `HEAD` symref, with fallbacks, so it
+  works on `main`, `master`, `development`, or `trunk` without configuration
+- **Checkout-free updates** - `sync` fast-forwards the default branch while you stay on
+  your feature branch
+- **fzf and gum throughout** - branch and file pickers with live diff previews, gum
+  spinners for fetches, gum multi-select before any deletion
+- **Dry run by default** - `cleanup` never deletes anything until you pass `--apply`
+- **Pipe friendly** - `--name-only` and the picker's selection both go to stdout, so they
+  compose with `xargs`
+
+## Requirements
+
+| Tool          | Needed for                                          |
+| ------------- | --------------------------------------------------- |
+| `git`         | everything                                          |
+| `fzf`         | branch and changed-file pickers (`changed -i`)      |
+| `gum`         | prompts, spinners, `cleanup` selection, `gitignore` |
+| `uv` and `gh` | `gitx pr` (delegates to `check-pr.sh`)              |
+
+`fzf` and `gum` are optional: without them the pickers degrade to non-interactive output
+and prompts fall back to a plain `read`.
+
+## Layout
+
+```
+gitx.sh                 # dispatcher: global options, command routing, help
+gitx/lib/common.sh      # colors, logging, git queries, fzf/gum helpers
+gitx/lib/status.sh      # gitx status
+gitx/lib/changed.sh     # gitx changed
+gitx/lib/branch.sh      # gitx branch
+gitx/lib/sync.sh        # gitx sync
+gitx/lib/cleanup.sh     # gitx cleanup
+gitx/lib/pr.sh          # gitx pr      -> check-pr.sh
+gitx/lib/gitignore.sh   # gitx gitignore -> gi-select.sh
+```
+
+## Commands
+
+### status
+
+Where you are relative to everything else, in seven lines.
+
+```bash
+gitx status
+gitx status --fetch      # refresh from the remote first so counts are current
+```
+
+```
+Repository  scripts (/Users/you/code/checkouts/personal/scripts)
+Branch      feat/git-tools
+Upstream    origin/feat/git-tools in sync
+Default     main (tracking origin/main)
+Position    ahead 3, behind 1 (rebase or merge to catch up)
+Worktree    0 staged, 1 unstaged, 9 untracked
+Stashes     none
+Last commit 2b3b0d6 Merge pull request #29 (5 days ago)
+```
+
+### changed
+
+Files a branch changed relative to the default branch, with added/removed line counts.
+The comparison is against the merge base, so commits that landed on the default branch
+afterwards are not reported as your changes.
+
+```bash
+gitx changed                        # current branch vs default branch
+gitx changed feat/other-work        # a specific branch
+gitx changed --dirty                # include uncommitted working tree changes
+gitx changed --base release/1.2     # compare against another base
+gitx changed --stat                 # git's own --stat rendering
+```
+
+```
+Base        origin/main (merge base 2b3b0d6)
+Head        feat/git-tools (3 commits)
+
+  +214   -0  gitx.sh
+  +197   -0  gitx/lib/cleanup.sh
+    +0   -3  README.md
+
+  3 files changed, +411, -3
+```
+
+Interactive mode picks the branch with fzf, then browses the changed files with a live
+diff preview. Selected paths are printed to stdout, so they pipe into anything:
+
+```bash
+gitx changed -i                          # browse with diff preview
+gitx changed -i --name-only | xargs $EDITOR
+gitx changed --name-only | xargs shellcheck
+```
+
+`-i` needs a terminal for the picker, but stdout can still be piped: fzf draws on
+`/dev/tty` and writes only the selection to stdout.
+
+### branch
+
+Create a conventionally named branch off an up-to-date default branch and switch to it.
+
+```bash
+gitx branch feat add git tools          # -> feat/add-git-tools
+gitx branch fix "PR status colours"     # -> fix/pr-status-colours
+gitx branch docs/gitx-usage             # contains a slash: used verbatim
+gitx branch --from v1.2.0 fix backport  # branch off a tag
+gitx branch -n feat try something       # print the name, create nothing
+gitx branch                             # gum prompts for type and description
+```
+
+Types: `feat` `fix` `docs` `chore` `refactor` `test` `perf` `ci` `build` `style`.
+Descriptions are slugified (lowercased, punctuation collapsed to hyphens) and the result
+is validated with `git check-ref-format` before anything is created.
+
+### sync
+
+Fetch with prune, fast-forward the default branch, then report divergence. The default
+branch is updated even while you are on a feature branch, using a fast-forward-only
+refspec fetch, so no checkout dance is needed. Nothing is rewritten unless you ask.
+
+```bash
+gitx sync                # fetch, fast-forward main, report status
+gitx sync --rebase       # ...and rebase the current branch onto main
+gitx sync --no-fetch     # report only, no network
+```
+
+If the local default branch has diverged from the remote, `sync` says so and leaves it
+alone rather than guessing.
+
+### cleanup
+
+Delete local branches whose work already landed, including squash-merged ones.
+
+```bash
+gitx cleanup                 # dry run: list what would go
+gitx cleanup --apply         # gum multi-select, everything preselected
+gitx cleanup --apply --yes   # no prompting, for scripts
+gitx cleanup --prune         # also drop stale remote-tracking refs
+gitx cleanup --no-squashed   # skip squash detection (faster on big repos)
+```
+
+```
+Base        origin/main
+Protected   main master feat/git-tools
+
+  feat/merged                merged         b965f89 3 days ago
+  feat/squashed              squash-merged  2ca13d5 2 days ago
+
+Dry run: nothing deleted. Re-run with --apply to delete these 2 branch(es).
+```
+
+The default branch, the current branch, `main`, and `master` are always protected. Add
+more with `GITX_PROTECTED_BRANCHES`. Merged branches are removed with `git branch -d`;
+only squash-merged ones need `-D`, since git cannot see the equivalence itself.
+
+**How squash detection works:** the branch's tree is replayed as a single commit on top of
+the merge base, then `git cherry` is asked whether an equivalent patch already exists on
+the default branch. The probe commit is never referenced, so it is garbage collected.
+
+### pr
+
+PR merge status, checks, reviews, and bot activity. Delegates to `check-pr.sh`, so every
+option it accepts works here.
+
+```bash
+gitx pr
+gitx pr --concise
+gitx pr -w                 # watch mode
+gitx pr -w -i 10           # watch, refreshing every 10 seconds
+```
+
+### gitignore
+
+Append GitHub's gitignore templates to `./.gitignore`, chosen with gum. Delegates to
+`gi-select.sh`.
+
+```bash
+gitx gitignore
+gitx gi
+```
+
+## Global Options
+
+```
+-h, --help              Show help (also: gitx help COMMAND)
+-V, --version           Show the gitx version
+-C, --directory DIR     Run as if gitx started in DIR
+    --remote NAME       Remote to use (default: origin, else the first remote)
+    --default-branch B  Override default branch detection
+    --no-color          Disable colored output
+```
+
+## Environment
+
+| Variable                  | Effect                                     |
+| ------------------------- | ------------------------------------------ |
+| `GITX_REMOTE`             | Default remote name                        |
+| `GITX_DEFAULT_BRANCH`     | Default branch name, skipping detection    |
+| `GITX_PROTECTED_BRANCHES` | Extra branches `cleanup` must never delete |
+| `NO_COLOR`                | Disable colored output                     |
+
+## Command Aliases
+
+| Command     | Aliases  |
+| ----------- | -------- |
+| `status`    | `st`     |
+| `changed`   | `files`  |
+| `branch`    | `new`    |
+| `sync`      | `update` |
+| `cleanup`   | `tidy`   |
+| `gitignore` | `gi`     |
+
+## Suggested Alias
+
+```bash
+alias gitx='~/code/checkouts/personal/scripts/gitx.sh'
+```
+
+## Notes and Gotchas
+
+- **`changed` on a mode-only change** reports `+0 -0`. That matches `git diff --numstat`;
+  the file did change (its mode), just not its contents.
+- **`cleanup` costs a few git calls per branch** when squash detection is on
+  (`merge-base`, `rev-parse`, `commit-tree`, `cherry`). On a repo with hundreds of stale
+  branches, `--no-squashed` is noticeably faster.
+- **`sync --rebase` refuses to run with a dirty tree.** Commit or stash first; it will not
+  stash on your behalf.
+- **Uncommitted changes carry over** when `branch` switches, which is normal git
+  behaviour. It warns so the carry-over is not a surprise.

--- a/gitx.sh
+++ b/gitx.sh
@@ -57,10 +57,12 @@ ENVIRONMENT:
     GITX_REMOTE             Default remote name
     GITX_DEFAULT_BRANCH     Default branch name, skipping detection
     GITX_PROTECTED_BRANCHES Extra branches cleanup must never delete
+    GITX_STATUS_COMPARE     Default --vs refs for status
     NO_COLOR                Disable colored output
 
 EXAMPLES:
     $(basename "$0") status
+    $(basename "$0") status --vs main           # also compare against a deploy branch
     $(basename "$0") changed                    # what this branch touches vs main
     $(basename "$0") changed feat/other-work
     $(basename "$0") branch feat add git tools  # -> feat/add-git-tools

--- a/gitx.sh
+++ b/gitx.sh
@@ -41,7 +41,8 @@ COMMANDS:
     branch, new         Create a TYPE/description branch off an up-to-date default branch
     sync, update        Fetch, fast-forward the default branch, report divergence
     cleanup, tidy       Delete local branches already merged or squash-merged
-    pr                  PR merge status, checks, reviews, bots (wraps check-pr.sh)
+    pr check            PR merge status, checks, reviews, bots (wraps check-pr.sh)
+    pr list             Open PRs with author and destination branch
     gitignore, gi       Append GitHub gitignore templates (wraps gi-select.sh)
     help [COMMAND]      Show help for a command
 
@@ -68,7 +69,8 @@ EXAMPLES:
     $(basename "$0") branch feat add git tools  # -> feat/add-git-tools
     $(basename "$0") sync --rebase
     $(basename "$0") cleanup --apply
-    $(basename "$0") pr --concise
+    $(basename "$0") pr check --concise
+    $(basename "$0") pr list --mine
     $(basename "$0") -C ~/code/other-repo status
 EOF
 }
@@ -94,7 +96,11 @@ cmd_help() {
             show_cleanup_help
             ;;
         pr)
-            show_pr_help
+            case "${2:-}" in
+                check) show_pr_check_help ;;
+                list | ls) show_pr_list_help ;;
+                *) show_pr_help ;;
+            esac
             ;;
         gitignore | gi)
             show_gitignore_help

--- a/gitx.sh
+++ b/gitx.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# gitx.sh - Git and GitHub workflow helpers behind one dispatcher
+# Wraps check-pr.sh and gi-select.sh alongside branch, sync, cleanup, status,
+# and changed-file subcommands.
+
+set -euo pipefail
+
+GITX_VERSION="1.0.0"
+GITX_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITX_LIB_DIR="$GITX_ROOT/gitx/lib"
+
+# shellcheck source=gitx/lib/common.sh
+source "$GITX_LIB_DIR/common.sh"
+# shellcheck source=gitx/lib/status.sh
+source "$GITX_LIB_DIR/status.sh"
+# shellcheck source=gitx/lib/changed.sh
+source "$GITX_LIB_DIR/changed.sh"
+# shellcheck source=gitx/lib/sync.sh
+source "$GITX_LIB_DIR/sync.sh"
+# shellcheck source=gitx/lib/cleanup.sh
+source "$GITX_LIB_DIR/cleanup.sh"
+# shellcheck source=gitx/lib/branch.sh
+source "$GITX_LIB_DIR/branch.sh"
+# shellcheck source=gitx/lib/pr.sh
+source "$GITX_LIB_DIR/pr.sh"
+# shellcheck source=gitx/lib/gitignore.sh
+source "$GITX_LIB_DIR/gitignore.sh"
+
+show_help() {
+    cat << EOF
+Usage: $(basename "$0") [GLOBAL_OPTIONS] COMMAND [COMMAND_OPTIONS]
+
+Git and GitHub workflow helpers for the everyday feature-branch loop: start a
+branch, see what it changed, check the PR, keep up with the default branch, and
+clean up afterwards.
+
+COMMANDS:
+    status, st          Branch, upstream, default-branch, worktree, and stash summary
+    changed, files      Files a branch changed vs the default branch, with +/- counts
+    branch, new         Create a TYPE/description branch off an up-to-date default branch
+    sync, update        Fetch, fast-forward the default branch, report divergence
+    cleanup, tidy       Delete local branches already merged or squash-merged
+    pr                  PR merge status, checks, reviews, bots (wraps check-pr.sh)
+    gitignore, gi       Append GitHub gitignore templates (wraps gi-select.sh)
+    help [COMMAND]      Show help for a command
+
+GLOBAL OPTIONS:
+    -h, --help              Show this help message
+    -V, --version           Show the gitx version
+    -C, --directory DIR     Run as if gitx started in DIR
+        --remote NAME       Remote to use (default: origin, else the first remote)
+        --default-branch B  Override default branch detection
+        --no-color          Disable colored output
+
+ENVIRONMENT:
+    GITX_REMOTE             Default remote name
+    GITX_DEFAULT_BRANCH     Default branch name, skipping detection
+    GITX_PROTECTED_BRANCHES Extra branches cleanup must never delete
+    NO_COLOR                Disable colored output
+
+EXAMPLES:
+    $(basename "$0") status
+    $(basename "$0") changed                    # what this branch touches vs main
+    $(basename "$0") changed feat/other-work
+    $(basename "$0") branch feat add git tools  # -> feat/add-git-tools
+    $(basename "$0") sync --rebase
+    $(basename "$0") cleanup --apply
+    $(basename "$0") pr --concise
+    $(basename "$0") -C ~/code/other-repo status
+EOF
+}
+
+cmd_help() {
+    case "${1:-}" in
+        "")
+            show_help
+            ;;
+        status | st)
+            show_status_help
+            ;;
+        changed | files)
+            show_changed_help
+            ;;
+        branch | new)
+            show_branch_help
+            ;;
+        sync | update)
+            show_sync_help
+            ;;
+        cleanup | tidy)
+            show_cleanup_help
+            ;;
+        pr)
+            show_pr_help
+            ;;
+        gitignore | gi)
+            show_gitignore_help
+            ;;
+        *)
+            error "no help topic for '$1'; run '$(basename "$0") --help'"
+            ;;
+    esac
+}
+
+main() {
+    local command=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_help
+                return 0
+                ;;
+            -V | --version)
+                printf 'gitx %s\n' "$GITX_VERSION"
+                return 0
+                ;;
+            -C | --directory)
+                [[ $# -ge 2 ]] || error "-C requires a directory"
+                cd "$2" || error "cannot change directory to '$2'"
+                shift 2
+                ;;
+            --remote)
+                [[ $# -ge 2 ]] || error "--remote requires a name"
+                GITX_REMOTE="$2"
+                shift 2
+                ;;
+            --default-branch)
+                [[ $# -ge 2 ]] || error "--default-branch requires a name"
+                GITX_DEFAULT_BRANCH="$2"
+                shift 2
+                ;;
+            --no-color)
+                NO_COLOR=1
+                gitx_init_colors
+                shift
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                error "unknown global option: $1 (run '$(basename "$0") --help')"
+                ;;
+            *)
+                command="$1"
+                shift
+                break
+                ;;
+        esac
+    done
+
+    if [[ -z "$command" ]]; then
+        show_help
+        return 0
+    fi
+
+    case "$command" in
+        status | st)
+            cmd_status "$@"
+            ;;
+        changed | files)
+            cmd_changed "$@"
+            ;;
+        branch | new)
+            cmd_branch "$@"
+            ;;
+        sync | update)
+            cmd_sync "$@"
+            ;;
+        cleanup | tidy)
+            cmd_cleanup "$@"
+            ;;
+        pr)
+            cmd_pr "$@"
+            ;;
+        gitignore | gi)
+            cmd_gitignore "$@"
+            ;;
+        help)
+            cmd_help "$@"
+            ;;
+        *)
+            error "unknown command: $command (run '$(basename "$0") --help')"
+            ;;
+    esac
+}
+
+main "$@"

--- a/gitx/lib/branch.sh
+++ b/gitx/lib/branch.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# branch.sh - Create conventionally named feature branches off the default branch
+
+set -euo pipefail
+
+# Conventional-commit style prefixes used for branch names
+GITX_BRANCH_TYPES=(feat fix docs chore refactor test perf ci build style)
+
+show_branch_help() {
+    cat << EOF
+Usage: gitx branch [OPTIONS] [TYPE] [DESCRIPTION...]
+       gitx branch [OPTIONS] TYPE/NAME
+
+Create a branch named TYPE/description-slug off an up-to-date default branch,
+then switch to it. The description is slugified: lowercased, spaces and
+punctuation collapsed to hyphens.
+
+TYPE is one of: ${GITX_BRANCH_TYPES[*]}
+An argument containing '/' is used verbatim. With no arguments, gum prompts
+for the type and description when available.
+
+OPTIONS:
+    -h, --help          Show this help message
+    -f, --from REF      Branch off REF instead of the default branch
+    -t, --type TYPE     Branch type when DESCRIPTION is given on its own
+    -n, --dry-run       Print the branch name that would be created
+        --no-fetch      Do not refresh the base ref from the remote
+
+EXAMPLES:
+    gitx branch feat add git tools          # -> feat/add-git-tools
+    gitx branch fix "PR status colours"     # -> fix/pr-status-colours
+    gitx branch docs/gitx-usage             # -> docs/gitx-usage (verbatim)
+    gitx branch --from v1.2.0 fix backport  # branch off a tag
+    gitx branch -n feat try something       # print the name, create nothing
+EOF
+}
+
+# Lowercase, collapse anything outside [a-z0-9._-] into single hyphens, trim
+gitx_slugify() {
+    printf '%s' "$*" \
+        | tr '[:upper:]' '[:lower:]' \
+        | tr -cs 'a-z0-9._-' '-' \
+        | sed -e 's/^-*//' -e 's/-*$//'
+}
+
+gitx_is_branch_type() {
+    local candidate="$1" entry
+    for entry in "${GITX_BRANCH_TYPES[@]}"; do
+        [[ "$candidate" != "$entry" ]] || return 0
+    done
+    return 1
+}
+
+cmd_branch() {
+    local from_ref=""
+    local type_option=""
+    local dry_run=false
+    local do_fetch=true
+    local -a words=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_branch_help
+                return 0
+                ;;
+            -f | --from)
+                [[ $# -ge 2 ]] || error "--from requires a ref"
+                from_ref="$2"
+                shift 2
+                ;;
+            -t | --type)
+                [[ $# -ge 2 ]] || error "--type requires a value"
+                type_option="$2"
+                shift 2
+                ;;
+            -n | --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --no-fetch)
+                do_fetch=false
+                shift
+                ;;
+            --)
+                shift
+                words+=("$@")
+                break
+                ;;
+            -*)
+                error "unknown option for 'branch': $1"
+                ;;
+            *)
+                words+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    require_repo
+
+    local remote default
+    remote="$(gitx_remote)"
+
+    # Interactive fallback when nothing was supplied
+    if [[ ${#words[@]} -eq 0 && -z "$type_option" ]]; then
+        if command -v gum >/dev/null 2>&1 && [[ -t 0 ]]; then
+            type_option=$(gum choose --header 'Branch type' "${GITX_BRANCH_TYPES[@]}") \
+                || error "no branch type selected"
+            local description
+            description=$(gum input --placeholder 'short description' --header "Branch description") \
+                || error "no description entered"
+            [[ -n "$description" ]] || error "description cannot be empty"
+            words=("$description")
+        else
+            show_branch_help
+            error "nothing to do; pass a TYPE and DESCRIPTION"
+        fi
+    fi
+
+    # Work out the branch name
+    local name=""
+    if [[ ${#words[@]} -eq 1 && "${words[0]}" == */* ]]; then
+        name="${words[0]}"
+    else
+        local branch_type="$type_option"
+        local -a description_words=()
+        [[ ${#words[@]} -eq 0 ]] || description_words=("${words[@]}")
+
+        if [[ -z "$branch_type" && ${#description_words[@]} -gt 0 ]] \
+            && gitx_is_branch_type "${description_words[0]}"; then
+            branch_type="${description_words[0]}"
+            description_words=("${description_words[@]:1}")
+        fi
+
+        [[ -n "$branch_type" ]] || error "no branch type given; use 'gitx branch TYPE DESCRIPTION' or --type"
+        [[ ${#description_words[@]} -gt 0 ]] || error "no description given for '$branch_type' branch"
+
+        local slug
+        slug="$(gitx_slugify "${description_words[*]}")"
+        [[ -n "$slug" ]] || error "description slugified to an empty string"
+        name="$branch_type/$slug"
+    fi
+
+    git check-ref-format --branch "$name" >/dev/null 2>&1 \
+        || error "'$name' is not a valid branch name"
+
+    if [[ "$dry_run" == "true" ]]; then
+        printf '%s\n' "$name"
+        return 0
+    fi
+
+    if git show-ref --verify --quiet "refs/heads/$name"; then
+        error "branch '$name' already exists"
+    fi
+
+    # Resolve the start point
+    local start_point
+    if [[ -n "$from_ref" ]]; then
+        start_point="$from_ref"
+    else
+        default="$(gitx_require_default_branch "$remote")"
+        if [[ "$do_fetch" == "true" && -n "$remote" ]]; then
+            gitx_spin "Fetching $remote/$default..." git fetch --quiet "$remote" "$default" \
+                || warn "fetch from '$remote' failed; using local refs"
+        fi
+        start_point="$(gitx_tracking_ref "$default" "$remote")"
+    fi
+
+    git rev-parse --verify --quiet "$start_point^{commit}" >/dev/null \
+        || error "start point '$start_point' does not exist"
+
+    if gitx_is_dirty; then
+        warn "uncommitted changes will carry over to the new branch"
+    fi
+
+    git checkout -b "$name" "$start_point" >/dev/null 2>&1 \
+        || error "could not create branch '$name' from '$start_point'"
+
+    success "created $name from $start_point"
+}

--- a/gitx/lib/changed.sh
+++ b/gitx/lib/changed.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# changed.sh - List files a branch changes relative to the default branch
+
+set -euo pipefail
+
+show_changed_help() {
+    cat << EOF
+Usage: gitx changed [OPTIONS] [BRANCH]
+
+List the files BRANCH changes relative to the default branch, with per-file
+added/removed line counts. Defaults to the current branch.
+
+The comparison uses the merge base, so commits that landed on the default
+branch after BRANCH was created are never reported as changes.
+
+OPTIONS:
+    -h, --help          Show this help message
+    -b, --base REF      Compare against REF instead of the default branch
+    -d, --dirty         Include uncommitted working tree changes
+    -i, --interactive   Pick the branch with fzf, then browse the changed files
+                        with a live diff preview; selected paths go to stdout
+        --name-only     Print only paths, one per line (script friendly)
+        --stat          Defer to git's own --stat rendering
+
+EXAMPLES:
+    gitx changed                        # current branch vs default branch
+    gitx changed feat/git-tools         # a specific branch vs default branch
+    gitx changed --dirty                # include uncommitted work
+    gitx changed --base release/1.2     # compare against another base
+    gitx changed -i                     # fzf browser with diff preview
+    gitx changed -i --name-only | xargs \$EDITOR
+    gitx changed --name-only | xargs shellcheck
+EOF
+}
+
+cmd_changed() {
+    local head_ref=""
+    local base_override=""
+    local mode="table"
+    local include_dirty=false
+    local interactive=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_changed_help
+                return 0
+                ;;
+            -b | --base)
+                [[ $# -ge 2 ]] || error "--base requires a ref"
+                base_override="$2"
+                shift 2
+                ;;
+            -d | --dirty | --worktree)
+                include_dirty=true
+                shift
+                ;;
+            -i | --interactive)
+                interactive=true
+                shift
+                ;;
+            --name-only)
+                mode="names"
+                shift
+                ;;
+            --stat)
+                mode="stat"
+                shift
+                ;;
+            -*)
+                error "unknown option for 'changed': $1"
+                ;;
+            *)
+                [[ -z "$head_ref" ]] || error "unexpected argument: $1"
+                head_ref="$1"
+                shift
+                ;;
+        esac
+    done
+
+    require_repo
+
+    # With -i and no explicit branch, choose one with fzf. The current branch
+    # sorts near the top, so Enter usually accepts what you wanted anyway.
+    if [[ "$interactive" == "true" && -z "$head_ref" && "$include_dirty" == "false" ]] \
+        && gitx_has_tty && { gitx_has_fzf || gitx_has_gum; }; then
+        local picked
+        picked=$(gitx_pick_branch "Compare branch") || error "no branch selected"
+        [[ -n "$picked" ]] || error "no branch selected"
+        head_ref="$picked"
+    fi
+
+    local base
+    if [[ -n "$base_override" ]]; then
+        base="$base_override"
+    else
+        local default
+        default="$(gitx_require_default_branch)"
+        base="$(gitx_tracking_ref "$default")"
+    fi
+
+    git rev-parse --verify --quiet "$base^{commit}" >/dev/null \
+        || error "base ref '$base' does not exist"
+
+    local head_rev head_label
+    if [[ -n "$head_ref" ]]; then
+        git rev-parse --verify --quiet "$head_ref^{commit}" >/dev/null \
+            || error "ref '$head_ref' does not exist"
+        head_rev="$head_ref"
+        head_label="$head_ref"
+    else
+        head_rev="HEAD"
+        head_label="$(gitx_head_label)"
+    fi
+
+    if [[ "$include_dirty" == "true" && -n "$head_ref" ]]; then
+        error "--dirty compares the working tree, so it cannot be combined with a branch argument"
+    fi
+
+    local merge_base
+    merge_base=$(git merge-base "$base" "$head_rev") \
+        || error "'$base' and '$head_label' have no common ancestor"
+
+    local -a diff_args
+    if [[ "$include_dirty" == "true" ]]; then
+        diff_args=("$merge_base" "--")
+    else
+        diff_args=("$merge_base" "$head_rev" "--")
+    fi
+
+    # Preview command for the fzf browser; refs never contain spaces
+    local preview_range="$merge_base"
+    [[ "$include_dirty" == "true" ]] || preview_range="$merge_base $head_rev"
+
+    if [[ "$mode" == "names" ]]; then
+        if [[ "$interactive" == "true" ]]; then
+            git diff --name-only "${diff_args[@]}" \
+                | gitx_pick_paths "changed" "git diff --color=always $preview_range -- {}" || true
+        else
+            git diff --name-only "${diff_args[@]}"
+        fi
+        return 0
+    fi
+
+    local commits
+    commits=$(git rev-list --count "$merge_base..$head_rev")
+
+    local head_detail="$commits commit"
+    [[ "$commits" == "1" ]] || head_detail="$commits commits"
+    if [[ "$include_dirty" == "true" ]]; then
+        head_detail="$head_detail + working tree"
+    fi
+
+    field "Base" "$(printf '%s%s%s %s(merge base %s)%s' "$CYAN" "$base" "$NC" "$DIM" "$(git rev-parse --short "$merge_base")" "$NC")"
+    field "Head" "$(printf '%s%s%s %s(%s)%s' "$CYAN" "$head_label" "$NC" "$DIM" "$head_detail" "$NC")"
+    printf '\n'
+
+    if [[ "$mode" == "stat" ]]; then
+        git diff --stat "${diff_args[@]}"
+        return 0
+    fi
+
+    local numstat
+    numstat=$(git diff --numstat "${diff_args[@]}")
+
+    if [[ -z "$numstat" ]]; then
+        info "  No file changes."
+        return 0
+    fi
+
+    printf '%s\n' "$numstat" | awk \
+        -v green="$GREEN" -v red="$RED" -v dim="$DIM" -v nc="$NC" '
+        BEGIN { FS = "\t"; n = 0; wa = 0; wr = 0; total_added = 0; total_removed = 0; binaries = 0 }
+        {
+            n++
+            added[n] = $1
+            removed[n] = $2
+            path[n] = $3
+            if ($1 == "-") {
+                binaries++
+            } else {
+                total_added += $1
+                total_removed += $2
+            }
+            if (length($1) > wa) { wa = length($1) }
+            if (length($2) > wr) { wr = length($2) }
+        }
+        END {
+            for (i = 1; i <= n; i++) {
+                if (added[i] == "-") {
+                    printf "  %s%*s  %*s  %s (binary)%s\n", dim, wa + 1, "-", wr + 1, "-", path[i], nc
+                } else {
+                    printf "  %s%*s%s  %s%*s%s  %s\n", \
+                        green, wa + 1, "+" added[i], nc, \
+                        red, wr + 1, "-" removed[i], nc, \
+                        path[i]
+                }
+            }
+            printf "\n  %d file%s changed, %s+%d%s, %s-%d%s", \
+                n, (n == 1 ? "" : "s"), green, total_added, nc, red, total_removed, nc
+            if (binaries > 0) {
+                printf ", %d binary", binaries
+            }
+            printf "\n"
+        }'
+
+    # Browse the same files with a live diff preview; selections go to stdout so
+    # they can be piped into an editor or a linter
+    if [[ "$interactive" == "true" ]]; then
+        local selection
+        selection=$(git diff --name-only "${diff_args[@]}" \
+            | gitx_pick_paths "changed" "git diff --color=always $preview_range -- {}") || true
+        if [[ -n "$selection" ]]; then
+            printf '\n'
+            printf '%s\n' "$selection"
+        fi
+    fi
+}

--- a/gitx/lib/cleanup.sh
+++ b/gitx/lib/cleanup.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# cleanup.sh - Delete local branches already merged (including squash-merged)
+
+set -euo pipefail
+
+show_cleanup_help() {
+    cat << EOF
+Usage: gitx cleanup [OPTIONS]
+
+Find local branches whose work has already landed on the default branch and
+delete them. Squash-merged branches are detected too, which plain
+'git branch --merged' misses entirely.
+
+Dry run is the default: nothing is deleted until --apply is passed.
+
+The default branch, the current branch, main, and master are always protected.
+Add more via GITX_PROTECTED_BRANCHES (comma or space separated).
+
+OPTIONS:
+    -h, --help          Show this help message
+        --apply         Actually delete the branches (prompts once)
+        --dry-run       Report only (default)
+        --no-squashed   Skip squash-merge detection (faster on big repos)
+    -p, --prune         Also prune stale remote-tracking refs
+    -y, --yes           Skip the confirmation prompt (implies --apply)
+
+EXAMPLES:
+    gitx cleanup                # list what would be deleted
+    gitx cleanup --apply        # delete after confirming
+    gitx cleanup --apply --yes  # delete without prompting
+    gitx cleanup --prune        # also drop stale origin/* refs
+EOF
+}
+
+cmd_cleanup() {
+    local apply=false
+    local check_squashed=true
+    local do_prune=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_cleanup_help
+                return 0
+                ;;
+            --apply)
+                apply=true
+                shift
+                ;;
+            --dry-run)
+                apply=false
+                shift
+                ;;
+            --no-squashed)
+                check_squashed=false
+                shift
+                ;;
+            -p | --prune)
+                do_prune=true
+                shift
+                ;;
+            -y | --yes)
+                apply=true
+                ASSUME_YES=true
+                shift
+                ;;
+            *)
+                error "unknown option for 'cleanup': $1"
+                ;;
+        esac
+    done
+
+    require_repo
+
+    local remote default current base
+    remote="$(gitx_remote)"
+    default="$(gitx_require_default_branch "$remote")"
+    current="$(gitx_current_branch)"
+    base="$(gitx_tracking_ref "$default" "$remote")"
+
+    git rev-parse --verify --quiet "$base^{commit}" >/dev/null \
+        || error "base ref '$base' does not exist"
+
+    # Protected branches: defaults plus anything the user configured, deduped
+    local -a candidates=("$default" "main" "master")
+    [[ -z "$current" ]] || candidates+=("$current")
+    if [[ -n "${GITX_PROTECTED_BRANCHES:-}" ]]; then
+        local -a extra=()
+        read -r -a extra <<< "${GITX_PROTECTED_BRANCHES//,/ }"
+        [[ ${#extra[@]} -eq 0 ]] || candidates+=("${extra[@]}")
+    fi
+
+    local -a protected=()
+    local candidate seen entry
+    for candidate in "${candidates[@]}"; do
+        seen=false
+        for entry in "${protected[@]+"${protected[@]}"}"; do
+            if [[ "$entry" == "$candidate" ]]; then
+                seen=true
+                break
+            fi
+        done
+        [[ "$seen" == "true" ]] || protected+=("$candidate")
+    done
+
+    field "Base" "$base"
+    field "Protected" "$(printf '%s ' "${protected[@]}" | sed 's/ $//')"
+    printf '\n'
+
+    local -a doomed_branches=() doomed_reasons=()
+    local branch reason
+
+    while IFS= read -r branch; do
+        local is_protected=false entry
+        for entry in "${protected[@]}"; do
+            if [[ "$branch" == "$entry" ]]; then
+                is_protected=true
+                break
+            fi
+        done
+        [[ "$is_protected" == "false" ]] || continue
+
+        reason=""
+        if gitx_is_merged "$branch" "$base"; then
+            reason="merged"
+        elif [[ "$check_squashed" == "true" ]] && gitx_is_squash_merged "$branch" "$base"; then
+            reason="squash-merged"
+        fi
+
+        if [[ -n "$reason" ]]; then
+            doomed_branches+=("$branch")
+            doomed_reasons+=("$reason")
+        fi
+    done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+
+    if [[ ${#doomed_branches[@]} -eq 0 ]]; then
+        info "No merged branches to clean up."
+    else
+        local index=0
+        for branch in "${doomed_branches[@]}"; do
+            reason="${doomed_reasons[$index]}"
+            printf '  %s%-40s%s %s%-14s%s %s%s%s\n' \
+                "$BOLD" "$branch" "$NC" \
+                "$CYAN" "$reason" "$NC" \
+                "$DIM" "$(git log -1 --format='%h %cr' "$branch")" "$NC"
+            index=$((index + 1))
+        done
+        printf '\n'
+
+        if [[ "$apply" != "true" ]]; then
+            info "${DIM}Dry run: nothing deleted. Re-run with --apply to delete these ${#doomed_branches[@]} branch(es).${NC}"
+        else
+            # Interactively, let gum narrow the list down; everything is
+            # preselected so a bare Enter deletes the lot
+            local -a chosen=()
+            if [[ "${ASSUME_YES:-false}" == "true" ]] || ! gitx_interactive || ! gitx_has_gum; then
+                if gitx_confirm "Delete ${#doomed_branches[@]} branch(es)?"; then
+                    chosen=("${doomed_branches[@]}")
+                fi
+            else
+                local selection preselected
+                preselected=$(
+                    IFS=,
+                    printf '%s' "${doomed_branches[*]}"
+                )
+                selection=$(printf '%s\n' "${doomed_branches[@]}" | gum choose \
+                    --no-limit \
+                    --selected "$preselected" \
+                    --header 'Delete which branches? (space toggles, enter confirms)') || true
+                if [[ -n "$selection" ]]; then
+                    while IFS= read -r line; do
+                        [[ -z "$line" ]] || chosen+=("$line")
+                    done <<< "$selection"
+                fi
+            fi
+
+            if [[ ${#chosen[@]} -eq 0 ]]; then
+                info "Nothing selected; no branches deleted."
+            else
+                for branch in "${chosen[@]}"; do
+                    # Recover the reason so merged branches use the safer -d
+                    reason="merged"
+                    index=0
+                    for entry in "${doomed_branches[@]}"; do
+                        if [[ "$entry" == "$branch" ]]; then
+                            reason="${doomed_reasons[$index]}"
+                            break
+                        fi
+                        index=$((index + 1))
+                    done
+
+                    # -d refuses squash-merged branches, so those need -D
+                    local -a delete_args=(-d)
+                    [[ "$reason" == "merged" ]] || delete_args=(-D)
+
+                    if git branch "${delete_args[@]}" "$branch" >/dev/null 2>&1; then
+                        success "deleted $branch ($reason)"
+                    else
+                        warn "could not delete '$branch'"
+                    fi
+                done
+            fi
+        fi
+    fi
+
+    if [[ "$do_prune" == "true" ]]; then
+        printf '\n'
+        if [[ -z "$remote" ]]; then
+            warn "no remote configured; skipping prune"
+        elif [[ "$apply" != "true" ]]; then
+            info "Stale remote-tracking refs that would be pruned:"
+            git remote prune --dry-run "$remote" || warn "prune check against '$remote' failed"
+        elif git remote prune "$remote"; then
+            success "pruned stale remote-tracking refs for $remote"
+        else
+            warn "prune against '$remote' failed"
+        fi
+    fi
+}

--- a/gitx/lib/common.sh
+++ b/gitx/lib/common.sh
@@ -97,12 +97,36 @@ gitx_remote() {
     git remote | head -n 1
 }
 
-# Resolve the default branch name without hitting the network:
-# GITX_DEFAULT_BRANCH, then the remote's HEAD symref, then common names as they
-# exist on the remote, then as local branches. Returns 1 when nothing matches.
+# Names to try when nothing authoritative is available, most common first. Only
+# ever a fallback: guessing from this list is what makes a repo whose default is
+# 'development' but which also has a 'main' look like a 'main' repo.
+GITX_DEFAULT_BRANCH_CANDIDATES=(main master development develop trunk mainline)
+
+# Ask the remote which branch its HEAD points at, then cache the answer in
+# refs/remotes/<remote>/HEAD so later runs resolve it locally.
+gitx_remote_head() {
+    local remote="$1"
+    local ref branch
+
+    ref=$(GIT_TERMINAL_PROMPT=0 git ls-remote --symref "$remote" HEAD 2>/dev/null \
+        | awk '$1 == "ref:" { print $2; exit }')
+    branch="${ref#refs/heads/}"
+    [[ -n "$branch" ]] || return 1
+
+    if git show-ref --verify --quiet "refs/remotes/$remote/$branch"; then
+        git symbolic-ref "refs/remotes/$remote/HEAD" "refs/remotes/$remote/$branch" 2>/dev/null || true
+    fi
+
+    printf '%s' "$branch"
+}
+
+# Resolve the default branch: GITX_DEFAULT_BRANCH, then the remote's cached HEAD
+# symref, then the remote itself when a local guess would be ambiguous, then
+# local branches. Returns 1 when nothing matches.
 gitx_default_branch() {
     local remote="${1:-}"
-    local ref candidate
+    local ref candidate branch
+    local -a matches=()
 
     if [[ -n "${GITX_DEFAULT_BRANCH:-}" ]]; then
         printf '%s' "$GITX_DEFAULT_BRANCH"
@@ -119,15 +143,33 @@ gitx_default_branch() {
     fi
 
     if [[ -n "$remote" ]]; then
-        for candidate in main master trunk develop; do
+        for candidate in "${GITX_DEFAULT_BRANCH_CANDIDATES[@]}"; do
             if git show-ref --verify --quiet "refs/remotes/$remote/$candidate"; then
-                printf '%s' "$candidate"
-                return 0
+                matches+=("$candidate")
             fi
         done
+
+        # Exactly one plausible name: trust it and stay offline. More than one
+        # (say both 'main' and 'development') makes any guess a coin flip, so
+        # ask the remote rather than pick wrong.
+        if [[ ${#matches[@]} -eq 1 ]]; then
+            printf '%s' "${matches[0]}"
+            return 0
+        fi
+
+        if branch=$(gitx_remote_head "$remote"); then
+            printf '%s' "$branch"
+            return 0
+        fi
+
+        if [[ ${#matches[@]} -gt 1 ]]; then
+            warn "could not ask '$remote' which branch is default; guessing '${matches[0]}'. Set GITX_DEFAULT_BRANCH or pass --default-branch"
+            printf '%s' "${matches[0]}"
+            return 0
+        fi
     fi
 
-    for candidate in main master trunk develop; do
+    for candidate in "${GITX_DEFAULT_BRANCH_CANDIDATES[@]}"; do
         if git show-ref --verify --quiet "refs/heads/$candidate"; then
             printf '%s' "$candidate"
             return 0

--- a/gitx/lib/common.sh
+++ b/gitx/lib/common.sh
@@ -297,14 +297,18 @@ gitx_header() {
 
 # Run a command behind a gum spinner, falling back to a plain progress line.
 # Usage: gitx_spin "Fetching origin..." git fetch --prune origin
+#
+# The command's stdout is preserved in both paths, so this is safe to wrap around
+# something whose output is captured. Progress text goes to stderr for the same
+# reason: it is not part of the command's output.
 gitx_spin() {
     local title="$1"
     shift
 
     if gitx_has_gum && gitx_interactive; then
-        gum spin --spinner dot --title "$title" --show-error -- "$@"
+        gum spin --spinner dot --title "$title" --show-output -- "$@"
     else
-        info "$title"
+        printf '%s\n' "$title" >&2
         "$@"
     fi
 }

--- a/gitx/lib/common.sh
+++ b/gitx/lib/common.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+#
+# common.sh - Shared helpers for gitx: colors, logging, and git repository queries
+
+set -euo pipefail
+
+# Guard against double sourcing
+if [[ -n "${GITX_COMMON_SOURCED:-}" ]]; then
+    return 0
+fi
+GITX_COMMON_SOURCED=1
+
+# Colors are initialized once at source time and can be re-initialized after
+# global option parsing (for example when --no-color is passed).
+gitx_init_colors() {
+    if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+        RED=$'\033[0;31m'
+        GREEN=$'\033[0;32m'
+        YELLOW=$'\033[1;33m'
+        CYAN=$'\033[0;36m'
+        DIM=$'\033[2m'
+        BOLD=$'\033[1m'
+        NC=$'\033[0m'
+    else
+        RED=''
+        GREEN=''
+        YELLOW=''
+        # shellcheck disable=SC2034  # CYAN is consumed by the sibling lib modules
+        CYAN=''
+        DIM=''
+        BOLD=''
+        NC=''
+    fi
+}
+
+gitx_init_colors
+
+error() {
+    printf '%sError:%s %s\n' "$RED" "$NC" "$*" >&2
+    exit 1
+}
+
+warn() {
+    printf '%sWarning:%s %s\n' "$YELLOW" "$NC" "$*" >&2
+}
+
+info() {
+    printf '%s\n' "$*"
+}
+
+success() {
+    printf '%s✓%s %s\n' "$GREEN" "$NC" "$*"
+}
+
+skipped() {
+    printf '%s-%s %s\n' "$DIM" "$NC" "$*"
+}
+
+heading() {
+    printf '%s%s%s\n' "$BOLD" "$*" "$NC"
+}
+
+# Print an aligned "Label  value" row used by status-style output
+field() {
+    printf '%s%-11s%s %s\n' "$DIM" "$1" "$NC" "$2"
+}
+
+require_command() {
+    local command_name="$1"
+
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        error "'$command_name' is required but not installed"
+    fi
+}
+
+require_repo() {
+    require_command git
+
+    if [[ "$(git rev-parse --is-inside-work-tree 2>/dev/null || true)" != "true" ]]; then
+        error "not inside a git working tree (cwd: $PWD)"
+    fi
+}
+
+# Resolve the remote to work against: GITX_REMOTE, else origin, else the first
+# configured remote. Prints an empty string for repositories with no remotes.
+gitx_remote() {
+    if [[ -n "${GITX_REMOTE:-}" ]]; then
+        printf '%s' "$GITX_REMOTE"
+        return 0
+    fi
+
+    if git remote get-url origin >/dev/null 2>&1; then
+        printf 'origin'
+        return 0
+    fi
+
+    git remote | head -n 1
+}
+
+# Resolve the default branch name without hitting the network:
+# GITX_DEFAULT_BRANCH, then the remote's HEAD symref, then common names as they
+# exist on the remote, then as local branches. Returns 1 when nothing matches.
+gitx_default_branch() {
+    local remote="${1:-}"
+    local ref candidate
+
+    if [[ -n "${GITX_DEFAULT_BRANCH:-}" ]]; then
+        printf '%s' "$GITX_DEFAULT_BRANCH"
+        return 0
+    fi
+
+    if [[ -z "$remote" ]]; then
+        remote="$(gitx_remote)"
+    fi
+
+    if [[ -n "$remote" ]] && ref=$(git symbolic-ref --quiet "refs/remotes/$remote/HEAD" 2>/dev/null); then
+        printf '%s' "${ref#refs/remotes/"$remote"/}"
+        return 0
+    fi
+
+    if [[ -n "$remote" ]]; then
+        for candidate in main master trunk develop; do
+            if git show-ref --verify --quiet "refs/remotes/$remote/$candidate"; then
+                printf '%s' "$candidate"
+                return 0
+            fi
+        done
+    fi
+
+    for candidate in main master trunk develop; do
+        if git show-ref --verify --quiet "refs/heads/$candidate"; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Same as gitx_default_branch but exits with actionable advice on failure
+gitx_require_default_branch() {
+    local default
+    if ! default=$(gitx_default_branch "${1:-}"); then
+        error "could not determine the default branch; pass --default-branch NAME or set GITX_DEFAULT_BRANCH"
+    fi
+    printf '%s' "$default"
+}
+
+# Prefer the remote-tracking ref for a branch, since it is usually fresher than
+# the local copy. Falls back to the local branch name.
+gitx_tracking_ref() {
+    local branch="$1"
+    local remote="${2:-}"
+
+    if [[ -z "$remote" ]]; then
+        remote="$(gitx_remote)"
+    fi
+
+    if [[ -n "$remote" ]] && git show-ref --verify --quiet "refs/remotes/$remote/$branch"; then
+        printf '%s/%s' "$remote" "$branch"
+        return 0
+    fi
+
+    printf '%s' "$branch"
+}
+
+# Current branch name, or empty when HEAD is detached
+gitx_current_branch() {
+    git symbolic-ref --quiet --short HEAD 2>/dev/null || true
+}
+
+# Human label for HEAD, falling back to a short sha when detached
+gitx_head_label() {
+    local branch
+    branch="$(gitx_current_branch)"
+
+    if [[ -n "$branch" ]]; then
+        printf '%s' "$branch"
+    else
+        printf 'detached at %s' "$(git rev-parse --short HEAD)"
+    fi
+}
+
+# Prints "<ahead> <behind>" for HEAD-ish $2 relative to base $1
+gitx_ahead_behind() {
+    git rev-list --left-right --count "$1...$2" 2>/dev/null | awk '{print $2, $1}'
+}
+
+# Prints "<staged> <unstaged> <untracked>"
+gitx_worktree_counts() {
+    local staged unstaged untracked
+
+    staged=$(git diff --cached --name-only | wc -l | tr -d '[:space:]')
+    unstaged=$(git diff --name-only | wc -l | tr -d '[:space:]')
+    untracked=$(git ls-files --others --exclude-standard | wc -l | tr -d '[:space:]')
+
+    printf '%s %s %s' "$staged" "$unstaged" "$untracked"
+}
+
+gitx_is_dirty() {
+    [[ -n "$(git status --porcelain --untracked-files=no)" ]]
+}
+
+# True when $1 is fully contained in $2
+gitx_is_merged() {
+    git merge-base --is-ancestor "$1" "$2" 2>/dev/null
+}
+
+# Detect squash merges: replay the branch tree as a single commit on top of the
+# merge base and ask whether an equivalent patch already exists in the base.
+# This is how squash-merged PRs are recognized, since they share no commits.
+gitx_is_squash_merged() {
+    local branch="$1"
+    local base="$2"
+    local merge_base tree probe
+
+    merge_base=$(git merge-base "$base" "$branch" 2>/dev/null) || return 1
+    tree=$(git rev-parse "$branch^{tree}" 2>/dev/null) || return 1
+
+    # Requires a committer identity; treat a failure as "not squash-merged"
+    probe=$(git commit-tree "$tree" -p "$merge_base" -m 'gitx squash-merge probe' 2>/dev/null) || return 1
+
+    [[ "$(git cherry "$base" "$probe" 2>/dev/null)" == "-"* ]]
+}
+
+# --- Interactive helpers (gum for prompts, fzf for pickers) -------------------
+
+gitx_has_gum() {
+    command -v gum >/dev/null 2>&1
+}
+
+gitx_has_fzf() {
+    command -v fzf >/dev/null 2>&1
+}
+
+gitx_interactive() {
+    [[ -t 0 && -t 1 ]]
+}
+
+# fzf and gum draw on /dev/tty rather than stdout, so a picker still works with
+# stdout piped ('gitx changed -i --name-only | xargs ...'). What they cannot do
+# without a controlling terminal is read keys, so that is what we test for.
+gitx_has_tty() {
+    [[ -c /dev/tty ]] && { true > /dev/tty; } 2>/dev/null
+}
+
+# Section title: styled through gum when we have a terminal, plain otherwise
+gitx_header() {
+    if gitx_has_gum && gitx_interactive; then
+        gum style --foreground 212 --bold "$*"
+    else
+        heading "$*"
+    fi
+}
+
+# Run a command behind a gum spinner, falling back to a plain progress line.
+# Usage: gitx_spin "Fetching origin..." git fetch --prune origin
+gitx_spin() {
+    local title="$1"
+    shift
+
+    if gitx_has_gum && gitx_interactive; then
+        gum spin --spinner dot --title "$title" --show-error -- "$@"
+    else
+        info "$title"
+        "$@"
+    fi
+}
+
+# Confirmation prompt. Honors ASSUME_YES, declines when non-interactive.
+gitx_confirm() {
+    local prompt="$1"
+    local reply
+
+    if [[ "${ASSUME_YES:-false}" == "true" ]]; then
+        return 0
+    fi
+
+    if ! gitx_interactive; then
+        warn "not running interactively; refusing to continue without --yes"
+        return 1
+    fi
+
+    if gitx_has_gum; then
+        gum confirm "$prompt"
+        return $?
+    fi
+
+    read -r -p "$prompt [y/N] " reply
+    [[ "$reply" =~ ^[Yy] ]]
+}
+
+# Pick one local branch, most recently committed first. fzf previews the
+# branch's recent history; gum filter is the fallback. Returns 1 if cancelled
+# or if neither tool is installed.
+gitx_pick_branch() {
+    local prompt="${1:-Select a branch}"
+    local branches
+
+    gitx_has_tty || return 1
+
+    branches=$(git for-each-ref --sort=-committerdate --format='%(refname:short)' refs/heads/)
+    [[ -n "$branches" ]] || return 1
+
+    if gitx_has_fzf; then
+        printf '%s\n' "$branches" | fzf \
+            --prompt="$prompt > " \
+            --height=60% \
+            --reverse \
+            --ansi \
+            --select-1 \
+            --exit-0 \
+            --preview='git log --oneline --graph --decorate --color=always -20 {}' \
+            --preview-window='right,60%'
+    elif gitx_has_gum; then
+        printf '%s\n' "$branches" | gum filter --placeholder "$prompt" --height 15
+    else
+        return 1
+    fi
+}
+
+# Pick paths from stdin, previewing each one with PREVIEW_COMMAND ('{}' is the
+# path). Selected paths go to stdout. Returns 1 if cancelled or unavailable.
+gitx_pick_paths() {
+    local prompt="$1"
+    local preview_command="$2"
+
+    gitx_has_tty || return 1
+
+    if gitx_has_fzf; then
+        fzf --multi \
+            --ansi \
+            --prompt="$prompt > " \
+            --height=90% \
+            --reverse \
+            --exit-0 \
+            --preview="$preview_command" \
+            --preview-window='right,65%,wrap' \
+            --bind='ctrl-/:toggle-preview'
+    elif gitx_has_gum; then
+        gum filter --no-limit --placeholder "$prompt" --height 20
+    else
+        return 1
+    fi
+}

--- a/gitx/lib/gitignore.sh
+++ b/gitx/lib/gitignore.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# gitignore.sh - Delegate to gi-select.sh for interactive .gitignore assembly
+
+set -euo pipefail
+
+show_gitignore_help() {
+    cat << EOF
+Usage: gitx gitignore
+
+Append one or more of GitHub's gitignore templates to the .gitignore in the
+current directory, chosen interactively with gum.
+
+Templates come from a local clone of github/gitignore at
+~/code/tools/gitignore, which is created on first use. Requires 'gum'.
+
+EXAMPLES:
+    gitx gitignore
+    gitx gi
+EOF
+}
+
+cmd_gitignore() {
+    local wrapper="$GITX_ROOT/gi-select.sh"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help | --gitx-help)
+                show_gitignore_help
+                return 0
+                ;;
+            *)
+                error "unknown option for 'gitignore': $1"
+                ;;
+        esac
+    done
+
+    [[ -x "$wrapper" ]] || error "gi-select.sh not found or not executable at $wrapper"
+
+    exec "$wrapper"
+}

--- a/gitx/lib/pr.sh
+++ b/gitx/lib/pr.sh
@@ -1,18 +1,45 @@
 #!/usr/bin/env bash
 #
-# pr.sh - Delegate to check-pr.sh for GitHub PR merge status
+# pr.sh - Pull request subcommands: status for this branch, and a listing that
+# shows who opened each PR and where it is headed
 
 set -euo pipefail
 
 show_pr_help() {
     cat << EOF
-Usage: gitx pr [CHECK_PR_OPTIONS] [DIRECTORY]
+Usage: gitx pr [SUBCOMMAND] [OPTIONS]
+
+Pull request helpers.
+
+SUBCOMMANDS:
+    check       Merge status of the PR for the current branch (default)
+    list, ls    Open PRs with author and destination branch
+
+With no subcommand, 'check' runs, so 'gitx pr' and 'gitx pr check' agree.
+Each subcommand has its own help:
+
+    gitx pr check --help
+    gitx pr list --help
+
+EXAMPLES:
+    gitx pr check
+    gitx pr check --concise
+    gitx pr list
+    gitx pr list --mine
+    gitx pr list --base main
+EOF
+}
+
+show_pr_check_help() {
+    cat << EOF
+Usage: gitx pr check [OPTIONS] [DIRECTORY]
 
 Show the merge status of the pull request for the current branch: color-coded
-blockers, check runs, reviews, and bot activity.
+blockers, check runs sorted worst-first with a previous-run comparison, reviews,
+and bot activity.
 
-This delegates to check-pr.sh, so every option it accepts works here. Run
-'gitx pr --help' for the full list, which currently includes:
+Delegates to check-pr.sh, so every option it accepts works here. Run
+'gitx pr check --help' for the authoritative list, which currently includes:
 
     -w, --watch         Refresh on an interval; 'r' refreshes now, 'q' quits
     -i, --interval SECS Watch refresh interval (default: 30)
@@ -20,23 +47,272 @@ This delegates to check-pr.sh, so every option it accepts works here. Run
     -C, --directory DIR Repository directory (defaults to the current one)
 
 EXAMPLES:
-    gitx pr
-    gitx pr --concise
-    gitx pr -w
-    gitx pr ~/code/checkouts/personal/scripts
+    gitx pr check
+    gitx pr check --concise
+    gitx pr check -w
+    gitx pr check ~/code/checkouts/personal/scripts
+EOF
+}
+
+show_pr_list_help() {
+    cat << EOF
+Usage: gitx pr list [OPTIONS]
+
+List pull requests with the two things 'gh pr list' leaves out of easy reach:
+who opened each one, and which branch it targets. A destination that is not the
+default branch is highlighted, since that is usually the interesting case (a
+release promotion, or a PR aimed at the wrong branch).
+
+OPTIONS:
+    -h, --help          Show this help message
+    -s, --state STATE   open, closed, merged, or all (default: open)
+    -b, --base REF      Only PRs targeting REF
+    -a, --author LOGIN  Only PRs by LOGIN
+    -m, --mine          Only your PRs (shorthand for --author @me)
+    -H, --head          Also show the source branch
+    -L, --limit N       Maximum PRs to list (default: 30)
+    -i, --interactive   Pick PRs with fzf; selected numbers go to stdout
+
+EXAMPLES:
+    gitx pr list
+    gitx pr list --mine
+    gitx pr list --base main            # what is queued for the deploy branch
+    gitx pr list --state merged -L 10
+    gitx pr list -i | xargs -n1 gh pr view
 EOF
 }
 
 cmd_pr() {
     local wrapper="$GITX_ROOT/check-pr.sh"
 
-    [[ -x "$wrapper" ]] || error "check-pr.sh not found or not executable at $wrapper"
+    case "${1:-check}" in
+        check)
+            [[ $# -eq 0 ]] || shift
+            [[ -x "$wrapper" ]] || error "check-pr.sh not found or not executable at $wrapper"
+            exec "$wrapper" "$@"
+            ;;
+        list | ls)
+            shift
+            cmd_pr_list "$@"
+            ;;
+        -h | --help | --gitx-help)
+            show_pr_help
+            ;;
+        -*)
+            # Back-compat: 'gitx pr --concise' still means 'gitx pr check --concise'
+            [[ -x "$wrapper" ]] || error "check-pr.sh not found or not executable at $wrapper"
+            exec "$wrapper" "$@"
+            ;;
+        *)
+            # check-pr also takes a directory positionally
+            if [[ -d "$1" ]]; then
+                [[ -x "$wrapper" ]] || error "check-pr.sh not found or not executable at $wrapper"
+                exec "$wrapper" "$@"
+            fi
+            error "unknown 'pr' subcommand: $1 (try 'gitx pr check' or 'gitx pr list')"
+            ;;
+    esac
+}
 
-    # check-pr.sh has its own help, so only intercept the bare 'gitx help pr' path
-    if [[ "${1:-}" == "--gitx-help" ]]; then
-        show_pr_help
+cmd_pr_list() {
+    local state="open"
+    local base_filter=""
+    local author_filter=""
+    local limit=30
+    local show_head=false
+    local interactive=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_pr_list_help
+                return 0
+                ;;
+            -s | --state)
+                [[ $# -ge 2 ]] || error "--state requires a value"
+                state="$2"
+                shift 2
+                ;;
+            -b | --base)
+                [[ $# -ge 2 ]] || error "--base requires a ref"
+                base_filter="$2"
+                shift 2
+                ;;
+            -a | --author)
+                [[ $# -ge 2 ]] || error "--author requires a login"
+                author_filter="$2"
+                shift 2
+                ;;
+            -m | --mine)
+                author_filter="@me"
+                shift
+                ;;
+            -H | --head)
+                show_head=true
+                shift
+                ;;
+            -L | --limit)
+                [[ $# -ge 2 ]] || error "--limit requires a number"
+                limit="$2"
+                shift 2
+                ;;
+            -i | --interactive)
+                interactive=true
+                shift
+                ;;
+            *)
+                error "unknown option for 'pr list': $1"
+                ;;
+        esac
+    done
+
+    case "$state" in
+        open | closed | merged | all) ;;
+        *) error "invalid --state '$state' (open, closed, merged, or all)" ;;
+    esac
+    [[ "$limit" =~ ^[0-9]+$ && "$limit" -gt 0 ]] || error "--limit must be a positive number"
+
+    require_repo
+    require_command gh
+    require_command jq
+
+    local default
+    default="$(gitx_default_branch || true)"
+
+    local -a gh_args=(
+        pr list --state "$state" --limit "$limit"
+        --json 'number,title,author,baseRefName,headRefName,isDraft,updatedAt,reviewDecision'
+    )
+    [[ -z "$base_filter" ]] || gh_args+=(--base "$base_filter")
+    [[ -z "$author_filter" ]] || gh_args+=(--author "$author_filter")
+
+    local json
+    json=$(gitx_spin "Listing $state pull requests..." gh "${gh_args[@]}") \
+        || error "'gh pr list' failed"
+
+    # number, author, head, base, marker, review, age seconds, title
+    local rows
+    rows=$(printf '%s' "$json" | jq -r '
+        .[] | [
+            (.number | tostring),
+            (.author.login // "unknown"),
+            .headRefName,
+            .baseRefName,
+            (if .isDraft then "draft" else "" end),
+            (.reviewDecision // ""),
+            ((now - (.updatedAt | fromdateiso8601)) | floor | tostring),
+            (.title | gsub("[\t\n]"; " "))
+        ] | @tsv')
+
+    if [[ -z "$rows" ]]; then
+        info "No $state pull requests found."
         return 0
     fi
 
-    exec "$wrapper" "$@"
+    local term_width
+    term_width=$(tput cols 2>/dev/null || echo 100)
+
+    local table
+    table=$(printf '%s\n' "$rows" | awk -F '\t' \
+        -v green="$GREEN" -v red="$RED" -v yellow="$YELLOW" -v cyan="$CYAN" \
+        -v dim="$DIM" -v bold="$BOLD" -v nc="$NC" \
+        -v default_branch="$default" -v show_head="$show_head" -v width="$term_width" '
+        function age(seconds) {
+            if (seconds < 3600)  { return int(seconds / 60) "m" }
+            if (seconds < 86400) { return int(seconds / 3600) "h" }
+            if (seconds < 604800) { return int(seconds / 86400) "d" }
+            return int(seconds / 604800) "w"
+        }
+        function shorten(text, limit) {
+            if (limit < 4) { limit = 4 }
+            return length(text) <= limit ? text : substr(text, 1, limit - 1) "…"
+        }
+        {
+            n++
+            number[n] = $1
+            author[n] = $2
+            head[n] = $3
+            base[n] = $4
+            draft[n] = $5
+            review[n] = $6
+            ago[n] = age($7 + 0)
+            title[n] = $8
+
+            # A PR aimed somewhere other than the default branch is the one you
+            # want to notice
+            offbase[n] = (default_branch != "" && $4 != default_branch)
+            if (offbase[n]) { offbase_count++ }
+
+            if (draft[n] != "") {
+                flag[n] = "draft"
+            } else if (review[n] == "CHANGES_REQUESTED") {
+                flag[n] = "changes"
+            } else if (review[n] == "APPROVED") {
+                flag[n] = "approved"
+            } else {
+                flag[n] = ""
+            }
+
+            if (length(number[n]) > w_number) { w_number = length(number[n]) }
+            if (length(author[n]) > w_author) { w_author = length(author[n]) }
+            if (length(base[n]) > w_base) { w_base = length(base[n]) }
+            if (length(flag[n]) > w_flag) { w_flag = length(flag[n]) }
+            if (length(ago[n]) > w_age) { w_age = length(ago[n]) }
+            if (show_head == "true" && length(head[n]) > w_head) { w_head = length(head[n]) }
+        }
+        END {
+            if (w_head > 28) { w_head = 28 }
+            if (w_base > 22) { w_base = 22 }
+
+            # Everything except the title has a known width; the title gets what
+            # is left of the terminal
+            fixed = 2 + w_number + 2 + w_author + 2 + w_base + 2 + w_flag + 2 + w_age + 2
+            if (show_head == "true") { fixed += w_head + 4 }
+            title_width = width - fixed
+            if (title_width < 24) { title_width = 24 }
+
+            for (i = 1; i <= n; i++) {
+                base_style = offbase[i] ? yellow : dim
+                if (flag[i] == "changes")      { flag_style = red }
+                else if (flag[i] == "approved") { flag_style = green }
+                else if (flag[i] == "draft")    { flag_style = dim }
+                else                            { flag_style = nc }
+
+                line = sprintf("  %s%*s%s  %s%-*s%s", \
+                    bold, w_number, number[i], nc, \
+                    cyan, w_author, shorten(author[i], w_author), nc)
+
+                if (show_head == "true") {
+                    line = line sprintf("  %s%-*s%s →", dim, w_head, shorten(head[i], w_head), nc)
+                }
+
+                line = line sprintf("  %s%-*s%s  %s%-*s%s  %-*s  %s%s%s", \
+                    base_style, w_base, shorten(base[i], w_base), nc, \
+                    flag_style, w_flag, flag[i], nc, \
+                    title_width, shorten(title[i], title_width), \
+                    dim, ago[i], nc)
+
+                print line
+            }
+
+            printf "\n  %s%d pull request%s", dim, n, (n == 1 ? "" : "s")
+            if (offbase_count > 0 && default_branch != "") {
+                printf ", %s%d not targeting %s%s", yellow, offbase_count, default_branch, dim
+            }
+            printf "%s\n", nc
+        }')
+
+    if [[ "$interactive" != "true" ]]; then
+        printf '%s\n' "$table"
+        return 0
+    fi
+
+    # Selected PR numbers go to stdout so they compose with gh. fzf substitutes
+    # {1} (the number) into the preview itself, so it stays unexpanded here.
+    local selection
+    selection=$(printf '%s\n' "$rows" | awk -F '\t' '{ printf "%s\t%s\t%s → %s\t%s\n", $1, $2, $3, $4, $8 }' \
+        | gitx_pick_paths "pull request" 'gh pr view {1}' \
+        | awk -F '\t' '{ print $1 }') || true
+
+    [[ -z "$selection" ]] || printf '%s\n' "$selection"
 }

--- a/gitx/lib/pr.sh
+++ b/gitx/lib/pr.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# pr.sh - Delegate to check-pr.sh for GitHub PR merge status
+
+set -euo pipefail
+
+show_pr_help() {
+    cat << EOF
+Usage: gitx pr [CHECK_PR_OPTIONS] [DIRECTORY]
+
+Show the merge status of the pull request for the current branch: color-coded
+blockers, check runs, reviews, and bot activity.
+
+This delegates to check-pr.sh, so every option it accepts works here. Run
+'gitx pr --help' for the full list, which currently includes:
+
+    -w, --watch         Refresh every 30 seconds
+        --concise       Show only the summary and items needing attention
+    -C, --directory DIR Repository directory (defaults to the current one)
+
+EXAMPLES:
+    gitx pr
+    gitx pr --concise
+    gitx pr -w
+    gitx pr ~/code/checkouts/personal/scripts
+EOF
+}
+
+cmd_pr() {
+    local wrapper="$GITX_ROOT/check-pr.sh"
+
+    [[ -x "$wrapper" ]] || error "check-pr.sh not found or not executable at $wrapper"
+
+    # check-pr.sh has its own help, so only intercept the bare 'gitx help pr' path
+    if [[ "${1:-}" == "--gitx-help" ]]; then
+        show_pr_help
+        return 0
+    fi
+
+    exec "$wrapper" "$@"
+}

--- a/gitx/lib/pr.sh
+++ b/gitx/lib/pr.sh
@@ -14,7 +14,8 @@ blockers, check runs, reviews, and bot activity.
 This delegates to check-pr.sh, so every option it accepts works here. Run
 'gitx pr --help' for the full list, which currently includes:
 
-    -w, --watch         Refresh every 30 seconds
+    -w, --watch         Refresh on an interval; 'r' refreshes now, 'q' quits
+    -i, --interval SECS Watch refresh interval (default: 30)
         --concise       Show only the summary and items needing attention
     -C, --directory DIR Repository directory (defaults to the current one)
 

--- a/gitx/lib/status.sh
+++ b/gitx/lib/status.sh
@@ -14,18 +14,30 @@ relative to the default branch, working tree state, stashes, and last commit.
 Unlike 'git status', this answers "where am I relative to everything else"
 in a handful of lines.
 
+Use --vs to also compare against another branch, which is what you want when
+the default branch is not the branch you deploy from. Repeat it for more, or
+set GITX_STATUS_COMPARE once per repo.
+
 OPTIONS:
     -h, --help          Show this help message
     -f, --fetch         Fetch from the remote first so counts are current
+        --vs REF        Also report ahead/behind against REF (repeatable)
+
+ENVIRONMENT:
+    GITX_STATUS_COMPARE Default --vs refs, comma or space separated
 
 EXAMPLES:
     gitx status
     gitx status --fetch
+    gitx status --vs main               # e.g. development is default, main deploys
+    gitx status --vs main --vs staging
+    GITX_STATUS_COMPARE=main gitx status
 EOF
 }
 
 cmd_status() {
     local do_fetch=false
+    local -a compare_refs=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -37,11 +49,20 @@ cmd_status() {
                 do_fetch=true
                 shift
                 ;;
+            --vs | --against)
+                [[ $# -ge 2 ]] || error "--vs requires a ref"
+                compare_refs+=("$2")
+                shift 2
+                ;;
             *)
                 error "unknown option for 'status': $1"
                 ;;
         esac
     done
+
+    if [[ ${#compare_refs[@]} -eq 0 && -n "${GITX_STATUS_COMPARE:-}" ]]; then
+        read -r -a compare_refs <<< "${GITX_STATUS_COMPARE//,/ }"
+    fi
 
     require_repo
 
@@ -101,6 +122,24 @@ cmd_status() {
     else
         field "Default" "${DIM}unknown${NC}"
     fi
+
+    # Extra comparisons, for repos where the deploy branch is not the default
+    local compare_ref resolved counts ahead behind detail
+    for compare_ref in "${compare_refs[@]+"${compare_refs[@]}"}"; do
+        resolved="$(gitx_tracking_ref "$compare_ref" "$remote")"
+        if ! git rev-parse --verify --quiet "$resolved^{commit}" > /dev/null; then
+            field "Compare" "${YELLOW}$compare_ref not found${NC}"
+            continue
+        fi
+        counts="$(gitx_ahead_behind "$resolved" HEAD)"
+        ahead="${counts% *}"
+        behind="${counts#* }"
+        detail="ahead $ahead, behind $behind vs $resolved"
+        if [[ "$ahead" == "0" ]]; then
+            detail="$detail ${DIM}(fully contained)${NC}"
+        fi
+        field "Compare" "$detail"
+    done
 
     # Working tree
     local counts staged unstaged untracked

--- a/gitx/lib/status.sh
+++ b/gitx/lib/status.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# status.sh - Compact working tree, upstream, and default-branch summary
+
+set -euo pipefail
+
+show_status_help() {
+    cat << EOF
+Usage: gitx status [OPTIONS]
+
+Compact repository summary: current branch, upstream divergence, position
+relative to the default branch, working tree state, stashes, and last commit.
+
+Unlike 'git status', this answers "where am I relative to everything else"
+in a handful of lines.
+
+OPTIONS:
+    -h, --help          Show this help message
+    -f, --fetch         Fetch from the remote first so counts are current
+
+EXAMPLES:
+    gitx status
+    gitx status --fetch
+EOF
+}
+
+cmd_status() {
+    local do_fetch=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_status_help
+                return 0
+                ;;
+            -f | --fetch)
+                do_fetch=true
+                shift
+                ;;
+            *)
+                error "unknown option for 'status': $1"
+                ;;
+        esac
+    done
+
+    require_repo
+
+    local remote branch default toplevel
+    remote="$(gitx_remote)"
+    branch="$(gitx_current_branch)"
+    toplevel="$(git rev-parse --show-toplevel)"
+
+    if [[ "$do_fetch" == "true" ]]; then
+        if [[ -z "$remote" ]]; then
+            warn "no remote configured; skipping fetch"
+        else
+            gitx_spin "Fetching $remote..." git fetch --quiet --prune "$remote" \
+                || warn "fetch from '$remote' failed"
+        fi
+    fi
+
+    field "Repository" "$(basename "$toplevel") $DIM($toplevel)$NC"
+    field "Branch" "${BOLD}$(gitx_head_label)${NC}"
+
+    # Upstream divergence
+    local upstream
+    if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null); then
+        local counts ahead behind detail
+        counts="$(gitx_ahead_behind "$upstream" HEAD)"
+        ahead="${counts% *}"
+        behind="${counts#* }"
+
+        if [[ "$ahead" == "0" && "$behind" == "0" ]]; then
+            detail="${GREEN}in sync${NC}"
+        else
+            detail="${YELLOW}ahead $ahead, behind $behind${NC}"
+        fi
+        field "Upstream" "$upstream $detail"
+    else
+        field "Upstream" "${DIM}none (unpublished branch)${NC}"
+    fi
+
+    # Position relative to the default branch
+    if default=$(gitx_default_branch "$remote"); then
+        local base counts ahead behind detail
+        base="$(gitx_tracking_ref "$default" "$remote")"
+        field "Default" "$default $DIM(tracking $base)$NC"
+
+        if [[ "$branch" == "$default" ]]; then
+            field "Position" "${DIM}on the default branch${NC}"
+        else
+            counts="$(gitx_ahead_behind "$base" HEAD)"
+            ahead="${counts% *}"
+            behind="${counts#* }"
+            detail="ahead $ahead, behind $behind vs $base"
+            if [[ "$behind" != "0" ]]; then
+                detail="$detail ${YELLOW}(rebase or merge to catch up)${NC}"
+            fi
+            field "Position" "$detail"
+        fi
+    else
+        field "Default" "${DIM}unknown${NC}"
+    fi
+
+    # Working tree
+    local counts staged unstaged untracked
+    counts="$(gitx_worktree_counts)"
+    staged="$(printf '%s' "$counts" | cut -d' ' -f1)"
+    unstaged="$(printf '%s' "$counts" | cut -d' ' -f2)"
+    untracked="$(printf '%s' "$counts" | cut -d' ' -f3)"
+
+    if [[ "$staged" == "0" && "$unstaged" == "0" && "$untracked" == "0" ]]; then
+        field "Worktree" "${GREEN}clean${NC}"
+    else
+        field "Worktree" "$(printf '%s%d staged%s, %s%d unstaged%s, %s%d untracked%s' \
+            "$GREEN" "$staged" "$NC" "$YELLOW" "$unstaged" "$NC" "$DIM" "$untracked" "$NC")"
+    fi
+
+    # Stashes
+    local stashes
+    stashes=$(git stash list | wc -l | tr -d '[:space:]')
+    if [[ "$stashes" == "0" ]]; then
+        field "Stashes" "${DIM}none${NC}"
+    else
+        field "Stashes" "$stashes"
+    fi
+
+    # Last commit
+    if git rev-parse --verify --quiet HEAD >/dev/null; then
+        field "Last commit" "$(git log -1 --format='%C(auto)%h%C(reset) %s %C(dim)(%cr)%C(reset)')"
+    else
+        field "Last commit" "${DIM}no commits yet${NC}"
+    fi
+}

--- a/gitx/lib/sync.sh
+++ b/gitx/lib/sync.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# sync.sh - Fetch, fast-forward the default branch, and report divergence
+
+set -euo pipefail
+
+show_sync_help() {
+    cat << EOF
+Usage: gitx sync [OPTIONS]
+
+Fetch with prune, fast-forward the default branch, then report how the current
+branch sits relative to its upstream and to the default branch.
+
+The default branch is updated even while you are on a feature branch, using a
+fast-forward-only refspec fetch, so no checkout dance is required. Nothing is
+rewritten unless --rebase is passed.
+
+OPTIONS:
+    -h, --help          Show this help message
+    -r, --rebase        Also rebase the current branch onto the default branch
+        --no-fetch      Skip the fetch and report using existing refs
+        --no-tags       Do not fetch tags
+
+EXAMPLES:
+    gitx sync                   # fetch, fast-forward main, report status
+    gitx sync --rebase          # ...and rebase the current branch onto main
+    gitx sync --no-fetch        # report only, no network
+EOF
+}
+
+cmd_sync() {
+    local do_fetch=true
+    local do_rebase=false
+    local fetch_tags=true
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h | --help)
+                show_sync_help
+                return 0
+                ;;
+            -r | --rebase)
+                do_rebase=true
+                shift
+                ;;
+            --no-fetch)
+                do_fetch=false
+                shift
+                ;;
+            --no-tags)
+                fetch_tags=false
+                shift
+                ;;
+            *)
+                error "unknown option for 'sync': $1"
+                ;;
+        esac
+    done
+
+    require_repo
+
+    local remote default branch
+    remote="$(gitx_remote)"
+    [[ -n "$remote" ]] || error "no remote configured; nothing to sync against"
+    default="$(gitx_require_default_branch "$remote")"
+    branch="$(gitx_current_branch)"
+
+    if [[ "$do_fetch" == "true" ]]; then
+        local -a fetch_args=(--prune "$remote")
+        [[ "$fetch_tags" == "true" ]] || fetch_args=(--no-tags "${fetch_args[@]}")
+
+        gitx_spin "Fetching $remote..." git fetch "${fetch_args[@]}" \
+            || error "fetch from '$remote' failed"
+        success "fetched $remote"
+    fi
+
+    git show-ref --verify --quiet "refs/remotes/$remote/$default" \
+        || error "'$remote/$default' not found; is '$default' the right default branch?"
+
+    # Fast-forward the default branch, whether or not it is checked out
+    if [[ "$branch" == "$default" ]]; then
+        if gitx_is_dirty; then
+            warn "working tree is dirty; skipping fast-forward of '$default'"
+        elif git merge-base --is-ancestor HEAD "$remote/$default"; then
+            if [[ "$(git rev-parse HEAD)" == "$(git rev-parse "$remote/$default")" ]]; then
+                skipped "$default already matches $remote/$default"
+            elif git merge --ff-only --quiet "$remote/$default"; then
+                success "fast-forwarded $default to $remote/$default"
+            else
+                warn "could not fast-forward '$default'"
+            fi
+        else
+            warn "local '$default' has commits not on '$remote/$default'; resolve manually"
+        fi
+    elif ! git show-ref --verify --quiet "refs/heads/$default"; then
+        if git fetch --quiet "$remote" "$default:$default"; then
+            success "created local $default from $remote/$default"
+        else
+            warn "could not create local '$default'"
+        fi
+    elif [[ "$(git rev-parse "$default")" == "$(git rev-parse "$remote/$default")" ]]; then
+        skipped "$default already matches $remote/$default"
+    elif git fetch --quiet "$remote" "$default:$default" 2>/dev/null; then
+        success "fast-forwarded $default to $remote/$default"
+    else
+        warn "local '$default' has diverged from '$remote/$default'; resolve manually"
+    fi
+
+    # Rebase the current branch if asked
+    if [[ "$do_rebase" == "true" ]]; then
+        if [[ -z "$branch" ]]; then
+            error "HEAD is detached; cannot rebase"
+        elif [[ "$branch" == "$default" ]]; then
+            skipped "already on '$default'; nothing to rebase"
+        elif gitx_is_dirty; then
+            error "working tree has uncommitted changes; commit or stash before rebasing"
+        elif git rebase "$remote/$default"; then
+            success "rebased $branch onto $remote/$default"
+        else
+            error "rebase onto '$remote/$default' failed; resolve conflicts or run 'git rebase --abort'"
+        fi
+    fi
+
+    printf '\n'
+    cmd_status
+}


### PR DESCRIPTION
Wraps the git tooling behind `gitx.sh` (dispatcher + `gitx/lib/` modules, following power-monitor's layout) and fixes several `check-pr` issues found while validating against real PRs.

## gitx

| Command | What it does |
|---|---|
| `status` / `st` | branch, upstream divergence, position vs default, worktree, stashes, last commit |
| `changed` / `files` | files a branch changed vs the default branch, with +/- line counts |
| `branch` / `new` | `gitx branch feat add git tools` → `feat/add-git-tools`, cut from an updated default |
| `sync` / `update` | fetch+prune, fast-forward the default branch *without* checking it out, report divergence, optional `--rebase` |
| `cleanup` / `tidy` | delete merged **and squash-merged** branches; dry run by default |
| `pr check` | PR merge status, checks, reviews, bots (wraps `check-pr.sh`) |
| `pr list` | open PRs with author and destination branch, off-target ones flagged |
| `gitignore` / `gi` | wraps `gi-select.sh` |

Two things that needed solving properly rather than as one-liners:

- **`changed` compares against the merge base**, so once `main` moves ahead its commits aren't attributed to your branch.
- **`cleanup` detects squash-merges** by replaying the branch tree as a single commit on the merge base and asking `git cherry` whether the patch already exists upstream. `git branch --merged` cannot see these at all, which is why they accumulate.

Default branch detection reads the remote's `HEAD` symref, and falls back to a name guess only when exactly one candidate exists. That matters for a repo whose default is `development` but which also has a `main`: guessing from a list would pick `main`, and every command built on it would then be wrong. On ambiguity it asks the remote with `git ls-remote --symref` and caches the answer into `refs/remotes/<remote>/HEAD`, so the network cost happens at most once. An unreachable remote still falls back to a guess, but says which one it picked and how to override it.

`status --vs REF` (repeatable, or `GITX_STATUS_COMPARE`) reports ahead/behind against another branch, since the branch a repo deploys from is not always its default:

```
Default     development (tracking origin/development)
Position    ahead 2, behind 0 vs origin/development
Compare     ahead 20, behind 21 vs origin/main
```

fzf drives the branch picker and the changed-file browser (live diff preview); gum handles prompts, spinners, and `cleanup` selection. Both are optional and degrade gracefully. Pickers gate on a usable `/dev/tty` rather than `-t 1`, so `gitx changed -i --name-only | xargs $EDITOR` still works with stdout piped.

## check-pr

**Sorting:** checks now go failing → pending → other → skipped → passing, alphabetical within a state, so rows stop reshuffling between watch refreshes.

**Short terminals:** the cause was Rich's `Live` silently cropping the bottom. Fetching (`collect_state`) is now split from rendering (`render_state`), so watch mode re-renders every tick at the current size — dropping passing checks first, then truncating with a `… N more line(s) hidden` marker. The footer always survives, and resizes adapt without refetching.

**Previous-run visibility:** new `Previous` (verdict + duration) and `Trend` columns, so a regression is obvious at a glance:

```
│ Pre-commit lint          │ FAILURE │ regressed   │ 4m53s │ SUCCESS 2m47s │
│ Backend Fast Tests (2/3) │ SUCCESS │ slower 2.3× │ 4m32s │ SUCCESS 1m58s │
│ Mobile Tests             │ SUCCESS │ faster 0.3× │ 1m11s │ SUCCESS 4m16s │
```

Trend covers `regressed`, `fixed`, `still failing`, `slower N×`, `faster N×`, and `running long N×` (a pending job overrunning its usual time — usually a hang). Regressions and overruns are promoted into "Needs attention". Verdict changes outrank timing changes, and thresholds need both a ratio and an absolute delta so short jobs don't flap.

### Bugs fixed

- **Previous durations came from cancelled runs**, so several unrelated jobs all reported the cancellation instant (identical bogus values). Cancelled runs are now excluded.
- **A `COMMENTED` review overwrote that reviewer's earlier `APPROVED`.** Only APPROVED/CHANGES_REQUESTED/DISMISSED are decisive now.
- Dead filter in `previous_durations` (`(name, "") not in wanted` was always true), and baselines picked whichever thread finished first rather than the newest run.
- Unclear failure when `gh repo view` returned nothing; added a `gh auth login` hint.

### Watch mode keybindings

`r` refreshes immediately and `q` quits, read through cbreak mode on stdin (cbreak rather than raw, so Ctrl-C still interrupts). It is skipped entirely when stdin is not a tty, so cron and pipes are unaffected. The footer advertises the keys and shows `refreshing now...` before the fetch blocks.

Since each refresh is several API calls, spam is contained two ways:

- A 3s cooldown on manual refreshes; a press inside the window is refused with `refreshed Ns ago, ignoring` rather than silently doing nothing.
- Keys buffered during an in-flight fetch are discarded, because a queued keypress would otherwise become one fetch per press. A `q` in that buffer is still honored, since a fetch can take seconds.

The interval is also timed from the end of a fetch rather than the start, so a slow fetch cannot immediately trigger the next one.

### pr list

`pr` is a group: `gitx pr check` is the old `gitx pr` (a bare `gitx pr` still runs it), and `gitx pr list` adds the two things that are awkward to get from `gh pr list` — who opened each PR, and where it is headed:

```
  1007  stonecharioteer  main         draft  chore: promote development to …  3m
   999  Bukkaraya        development  draft  Add admin-only chat model pick…  4d
   960  stonecharioteer  development         fix: fail fast on non-dev data…  1w

  12 pull requests, 1 not targeting development
```

A destination that is not the default branch is highlighted and counted, which surfaces both release promotions and PRs aimed at the wrong branch. The flag column shows `draft`/`approved`/`changes`, so the listing doubles as a review queue. Filters: `--state`, `--base`, `--author`, `--mine`, `--limit`, `-H` for the source branch, and `-i` to pick with fzf (selected numbers go to stdout, previewing `gh pr view`). One `gh pr list --json` call plus `jq`, so a single round trip.

### Idle repaints

`Live` was created with `refresh_per_second=4` and auto-refresh on, so Rich repainted the whole region four times a second whether or not anything had changed, and every table was re-rendered each tick just to advance the countdown. Now auto-refresh is off, a frame is painted only when it differs from what is on screen, and the body is rebuilt only when its inputs change (new data, terminal resize, concise toggle).

Measured idle with 21 checks and nothing changing:

| | before | after |
|---|---|---|
| painted frames | 4.0/s | 1.1/s (the countdown) |
| terminal output | 69,568 B | 19,451 B |

This does not need Textual. Rich already repositions the cursor instead of clearing the screen; Textual would only add per-cell updates, at the cost of turning a glanceable command into an async app.

### Faster, not slower

The run id is already in each check link, so job details are fetched **per workflow run** instead of one `gh api` per check, and the branch run-history fetch overlaps the job listings. `gh repo view` and `gh pr list` also run concurrently.

Measured on a real 24-check PR, 3 alternating rounds:

| | before | after |
|---|---|---|
| wall time | 6.67–6.81s | 3.90–4.06s |
| `gh` invocations | 41 | 18 |

Also adds `-i/--interval` for watch mode.

## Testing

- `shellcheck -x` clean on `gitx.sh` and all `gitx/lib/*.sh`; pre-commit hooks pass
- gitx exercised end to end in a throwaway repo covering merged, squash-merged, and live branches, plus detached HEAD, dirty trees, duplicate branch names, and a repo with no remote
- default branch detection tested against a repo built to mirror a `development`-default repo that also has `main`, with no cached `origin/HEAD`, plus override precedence and the unreachable-remote fallback
- check-pr internals unit-tested (sorting, trend logic, review resolution, height fitting) and validated end to end against live GitHub data, including the Actions job path
- `gitx_spin` fixed: its fallback printed progress to stdout, corrupting `$(...)` captures (`pr list` fed that text to jq). Progress goes to stderr now, and a pty test confirms the gum spinner never leaks into captured stdout
- watch mode driven through a pty: ten rapid `r` presses produce exactly one refresh, a press inside the cooldown starts no fetch, `r` works again once it lapses, and `q` exits cleanly

Test scripts are not included in this PR — happy to add them under `tests/` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
