### PR TITLE
fix(gitx): detect stale remote default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each script has detailed documentation in the [`docs/`](docs/) folder with compr
 - **[check-pr.sh](check-pr.sh)** - Show one-line GitHub PR merge status with color-coded blockers, checks sorted worst-first, runner/machine info, previous-run verdict and timing trend (regressed/fixed/slower), reviews, and bot activity (CodeRabbit, etc.)
 - **[env-diff.sh](docs/env-diff.md)** - Compare `.env` files in a gum table while redacting token-like values
 - **[gi-select.sh](docs/gi-select.md)** - Interactive .gitignore file generator using GitHub's gitignore templates
-- **[gitx.sh](docs/gitx.md)** - Git workflow dispatcher: branch status, merge-base changed files with +/- counts, conventional branch creation, checkout-free default-branch sync, squash-merge-aware branch cleanup, a PR listing with author and destination branch, and wrappers for check-pr and gi-select
+- **[gitx.sh](docs/gitx.md)** - Git workflow dispatcher: branch status, merge-base changed files with +/- counts and stale remote-HEAD protection, conventional branch creation, checkout-free default-branch sync, squash-merge-aware branch cleanup, a PR listing with author and destination branch, and wrappers for check-pr and gi-select
 - **[highlight-manager.sh](docs/highlight-manager.md)** - Manage Kindle highlights with DuckDB storage and beautiful terminal display
 
 ### Notifications

--- a/docs/gitx.md
+++ b/docs/gitx.md
@@ -30,7 +30,8 @@ colors, and interactive pickers.
   `git branch --merged` misses entirely
 - **Default branch detection** - reads the remote's `HEAD` symref, and asks the remote
   directly when a local guess would be ambiguous, so a repo whose default is `development`
-  but which also has a `main` is not mistaken for a `main` repo
+  but which also has a `main` is not mistaken for a `main` repo; `changed` also rejects a
+  stale cached remote `HEAD` before it can compare against the former default branch
 - **Deploy-branch awareness** - `status --vs main` reports where you sit relative to any
   other branch, for repos where the default branch is not the one you ship from
 - **Checkout-free updates** - `sync` fast-forwards the default branch while you stay on
@@ -113,7 +114,12 @@ A ref that does not exist is reported in place rather than being fatal, so a sta
 
 Files a branch changed relative to the default branch, with added/removed line counts.
 The comparison is against the merge base, so commits that landed on the default branch
-afterwards are not reported as your changes.
+afterwards are not reported as your changes. Before using a cached `origin/HEAD`, the
+command checks the remote when it is reachable. If the remote's default branch changed,
+it exits with an error and tells you to refresh the cache with
+`git remote set-head origin --auto`; this prevents merges from the real default branch
+being misreported as feature work. An explicit `--base` or `--default-branch` skips this
+check.
 
 ```bash
 gitx changed                        # current branch vs default branch

--- a/gitx/lib/changed.sh
+++ b/gitx/lib/changed.sh
@@ -95,9 +95,13 @@ cmd_changed() {
     if [[ -n "$base_override" ]]; then
         base="$base_override"
     else
-        local default
-        default="$(gitx_require_default_branch)"
-        base="$(gitx_tracking_ref "$default")"
+        local remote default
+        remote="$(gitx_remote)"
+        if [[ -z "${GITX_DEFAULT_BRANCH:-}" ]]; then
+            gitx_assert_remote_head_current "$remote"
+        fi
+        default="$(gitx_require_default_branch "$remote")"
+        base="$(gitx_tracking_ref "$default" "$remote")"
     fi
 
     git rev-parse --verify --quiet "$base^{commit}" >/dev/null \

--- a/gitx/lib/common.sh
+++ b/gitx/lib/common.sh
@@ -102,9 +102,9 @@ gitx_remote() {
 # 'development' but which also has a 'main' look like a 'main' repo.
 GITX_DEFAULT_BRANCH_CANDIDATES=(main master development develop trunk mainline)
 
-# Ask the remote which branch its HEAD points at, then cache the answer in
-# refs/remotes/<remote>/HEAD so later runs resolve it locally.
-gitx_remote_head() {
+# Ask the remote which branch its HEAD points at. This does not alter the local
+# refs/remotes/<remote>/HEAD cache.
+gitx_query_remote_head() {
     local remote="$1"
     local ref branch
 
@@ -113,11 +113,39 @@ gitx_remote_head() {
     branch="${ref#refs/heads/}"
     [[ -n "$branch" ]] || return 1
 
+    printf '%s' "$branch"
+}
+
+# Ask the remote which branch its HEAD points at, then cache the answer in
+# refs/remotes/<remote>/HEAD so later runs resolve it locally.
+gitx_remote_head() {
+    local remote="$1"
+    local branch
+
+    branch=$(gitx_query_remote_head "$remote") || return 1
+
     if git show-ref --verify --quiet "refs/remotes/$remote/$branch"; then
         git symbolic-ref "refs/remotes/$remote/HEAD" "refs/remotes/$remote/$branch" 2>/dev/null || true
     fi
 
     printf '%s' "$branch"
+}
+
+# Refuse a default-branch comparison when the remote changed its HEAD but the
+# local refs/remotes/<remote>/HEAD symref still points at the old branch. Stay
+# usable offline: an unreachable remote cannot prove that the cache is stale.
+gitx_assert_remote_head_current() {
+    local remote="$1"
+    local cached_ref cached_branch remote_branch
+
+    [[ -n "$remote" ]] || return 0
+    cached_ref=$(git symbolic-ref --quiet "refs/remotes/$remote/HEAD" 2>/dev/null) || return 0
+    cached_branch="${cached_ref#refs/remotes/"$remote"/}"
+    remote_branch=$(gitx_query_remote_head "$remote") || return 0
+
+    if [[ "$cached_branch" != "$remote_branch" ]]; then
+        error "'$remote' default branch changed from '$cached_branch' to '$remote_branch'; run 'git remote set-head $remote --auto' and retry"
+    fi
 }
 
 # Resolve the default branch: GITX_DEFAULT_BRANCH, then the remote's cached HEAD


### PR DESCRIPTION
## Summary

- verify the cached remote HEAD against the reachable remote before `gitx changed` selects its default base
- fail with an actionable `git remote set-head <remote> --auto` message when the default branch changed
- preserve explicit base/default overrides and offline behavior
- document stale remote-HEAD protection

## Testing

- `bash -n gitx.sh gitx/lib/*.sh`
- `shellcheck gitx.sh gitx/lib/*.sh`
- simulated a bare remote changing its HEAD from `main` to `development` and verified `gitx changed` exits with the expected error
- verified `--base origin/development` bypasses default-branch detection